### PR TITLE
reference correct class in code example

### DIFF
--- a/gettingstarted.md
+++ b/gettingstarted.md
@@ -34,7 +34,7 @@ public class GivenSomeStage<SELF extends GivenSomeStage<?>> extends Stage<SELF> 
    }
 }
 
-public class WhenSomeAction<SELF extends GivenSomeAction<?>> extends Stage<SELF> {
+public class WhenSomeAction<SELF extends WhenSomeAction<?>> extends Stage<SELF> {
    public SELF some_action() {
       return self();
    }


### PR DESCRIPTION
Hello Jan,

I found this trying the example. Too bad one can't reference source code from markdown to avoid this (only Asciidoctor AFAIK). 

Best regards,

Alexander