### PR TITLE
normalizing encoding and line endings in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,8 @@ subprojects {
     }
 
     tasks.withType(JavaCompile) {
+        // needed for DeSzenarioTest.java as it has Umlauts in the code
+        options.encoding = 'UTF-8'
         if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
             options.compilerArgs << "-parameters"
         }

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/report/html/ReportModelHtmlWriterTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/report/html/ReportModelHtmlWriterTest.java
@@ -38,7 +38,7 @@ public class ReportModelHtmlWriterTest extends ScenarioTestBase<GivenTestStep, W
         getScenario().finished();
         ReportModel model = getScenario().getModel();
         String string = ReportModelHtmlWriter.toString( model.getLastScenarioModel() );
-        assertThat( string.replace( '\n', ' ' ) ).matches(
+        assertThat( string.replace( System.getProperty("line.separator"), " ") ).matches(
             ".*"
                     + "<h3.*>.*Values can be multiplied.*</h3>.*"
                     + "<li><span class='introWord'>Given</span> <span class='argument'>" + a + "</span>.*and.*" + b + ".*</li>.*"

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/report/text/PlainTextReporterTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/report/text/PlainTextReporterTest.java
@@ -65,7 +65,7 @@ public class PlainTextReporterTest extends ScenarioTestBase<GivenTestStep, WhenT
             .but().something_else_not();
 
         String string = PlainTextReporter.toString( getScenario().getModel() );
-        assertThat( string )
+        assertThat( string.replaceAll(System.getProperty("line.separator"), "\n") )
             .contains( ""
                     + " Scenario: Test\n"
                     + "\n"
@@ -90,7 +90,7 @@ public class PlainTextReporterTest extends ScenarioTestBase<GivenTestStep, WhenT
             .something_else_not();
 
         String string = PlainTextReporter.toString( getScenario().getModel() );
-        assertThat( string )
+        assertThat( string.replaceAll(System.getProperty("line.separator"), "\n") )
             .contains( ""
                     + " Scenario: Test\n"
                     + "\n"

--- a/jgiven-tests/src/test/java/com/tngtech/jgiven/report/text/ThenPlainTextOutput.java
+++ b/jgiven-tests/src/test/java/com/tngtech/jgiven/report/text/ThenPlainTextOutput.java
@@ -14,7 +14,7 @@ public class ThenPlainTextOutput extends Stage<ThenPlainTextOutput> {
     String plainTextOutput;
 
     public ThenPlainTextOutput the_report_contains_text( String line ) {
-        Assertions.assertThat( plainTextOutput ).contains( line );
+        Assertions.assertThat( plainTextOutput.replace( System.getProperty("line.separator"), "\n" ) ).contains(line);
         return this;
     }
 


### PR DESCRIPTION
... to make the build work on Windows. The only other change I needed to do locally was to change `bower` to `bower.cmd` in `jgiven-html5-report\build.gradle`. Don't know yet how to make that flexible.