### PR TITLE
Upgrade to Paranamer 2.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ subprojects {
         assertjVersion = '1.7.0'
         slf4jVersion = '1.7.7'
         cglibVersion = '2.2.2'
-        paranamerVersion = '2.7'
+        paranamerVersion = '2.8'
         jansiVersion = '1.11'
         gsonVersion = '2.3'
         guavaVersion = '18.0'

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/util/ReflectionUtil.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/util/ReflectionUtil.java
@@ -3,7 +3,12 @@ package com.tngtech.jgiven.impl.util;
 import static java.lang.String.format;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.*;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 
@@ -249,7 +254,7 @@ public class ReflectionUtil {
             object.setAccessible( true );
         } catch( SecurityException e ) {
             log.debug( "Caught exception: ", e );
-            log.warn( "Could not make %s accessible, trying to access it nevertheless and hoping for the best.",
+            log.warn( "Could not make {} accessible, trying to access it nevertheless and hoping for the best.",
                 toReadableString( object ), errorDescription );
         }
     }

--- a/jgiven-java8-tests/src/test/java/com/tngtech/jgiven/tests/java8/Java8Test.java
+++ b/jgiven-java8-tests/src/test/java/com/tngtech/jgiven/tests/java8/Java8Test.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import com.tngtech.jgiven.junit.SimpleScenarioTest;
 import com.tngtech.jgiven.report.model.StepModel;
 
-public class Java8Test extends SimpleScenarioTest<LambdaSteps> {
+public class Java8Test extends SimpleScenarioTest<LambdaSteps<?>> {
 
     @Test
     public void lambda_steps_work() {


### PR DESCRIPTION
the upgrade fixes an incompatibility with Java 8 that required that for Java 8 JGiven had to use reflection based on the -parameters option of the javac compiler. With the new Paranamer version 2.8 this is not necessary anymore.