### PR TITLE
speedup travis by cache/containerizing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
 before_install:
 - npm install -g bower
+sudo: false
+cache:
+  directories:
+  - $HOME/.gradle
 install: "./gradlew classes"
 script:
 - "./gradlew test -DjunitVersion=4.9"


### PR DESCRIPTION
This adds some more options for the travis build. By caching the `.gradle` folder it saves about one minute per JDK matrix build. The total build time is down from ~20 min to ~17 min.

I considered adding a two dimensional build matrix with JDK x JUnit-Version, but then hesitated. Do you think this is useful? Will it interfere with `overallJacocoReport`?