### PR TITLE
Tags in html report can be used as direct links to external websites

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.9.4
+version=0.9.5-SNAPSHOT

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/IsTag.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/IsTag.java
@@ -1,6 +1,7 @@
 package com.tngtech.jgiven.annotation;
 
 import com.tngtech.jgiven.impl.tag.DefaultTagDescriptionGenerator;
+import com.tngtech.jgiven.impl.tag.DefaultTagHrefGenerator;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -138,5 +139,24 @@ public @interface IsTag {
      * @since 0.8.0
      */
     String style() default "";
+
+    /**
+     * An optional href of the tag that will appear in the generated report.
+     */
+    String href() default "";
+
+    /**
+     * An optional href generator that is used to dynamically generate
+     * the href depending on the concrete value of an annotation.
+     * <p>
+     * The class that implements {@link TagHrefGenerator} interface must
+     * be a public non-abstract class that is not a non-static inner class and must have a public default constructor.
+     * </p>
+     * <p>
+     * If this attribute is set, the {@link #href()} attribute is ignored.
+     * </p>
+     *
+     */
+    Class<? extends TagHrefGenerator> hrefGenerator() default DefaultTagHrefGenerator.class;
 
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/TagHrefGenerator.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/TagHrefGenerator.java
@@ -1,0 +1,33 @@
+package com.tngtech.jgiven.annotation;
+
+import com.tngtech.jgiven.config.TagConfiguration;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * Is used as an attribute of the {@link IsTag} annotation
+ * to dynamically generate an href for an annotation depending on its value.
+ * <p>
+ *     Implementations of this interface must be a public non-abstract class that is not a non-static inner class
+ *     and must have a public default constructor.
+ * </p>
+ */
+public interface TagHrefGenerator {
+
+    /**
+     * Implement this method to generate the href for the given annotation and its value.
+     * <p>
+     *     Note that when the value of the annotation is an array and {@link IsTag#explodeArray()}
+     *     is {@code true}, then this method is called for each value of the array and not once for the whole array.
+     *     Otherwise it is called only once.
+     * </p>
+     * @param tagConfiguration the configuration of the tag. The values typically correspond to the {@link IsTag annotation}.
+     *                         However, it is also possible to configure annotations to be tags using {@link JGivenConfiguration},
+     *                         in which case there is no {@link IsTag} annotation.
+     * @param annotation the actual annotation that was used as a tag
+     * @param value the value of the annotation. If the annotation has no value the default value is passed ({@link IsTag#value()}
+     *              
+     * @return the description of the annotation for the given value
+     */
+    String generateHref(TagConfiguration tagConfiguration, Annotation annotation, Object value);
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/config/TagConfiguration.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/config/TagConfiguration.java
@@ -4,8 +4,10 @@ import java.lang.annotation.Annotation;
 import java.util.List;
 
 import com.google.common.collect.Lists;
+import com.tngtech.jgiven.annotation.TagHrefGenerator;
 import com.tngtech.jgiven.impl.tag.DefaultTagDescriptionGenerator;
 import com.tngtech.jgiven.annotation.TagDescriptionGenerator;
+import com.tngtech.jgiven.impl.tag.DefaultTagHrefGenerator;
 
 /**
  * Represents the configuration of a tag.
@@ -25,6 +27,8 @@ public class TagConfiguration {
     private Class<? extends TagDescriptionGenerator> descriptionGenerator = DefaultTagDescriptionGenerator.class;
     private String name = "";
     private List<String> tags = Lists.newArrayList();
+    private String href = "";
+    private Class<? extends TagHrefGenerator> hrefGenerator = DefaultTagHrefGenerator.class;
 
     public TagConfiguration( Class<? extends Annotation> tagAnnotation ) {
         this.annotationType = tagAnnotation.getSimpleName();
@@ -102,6 +106,16 @@ public class TagConfiguration {
 
         public Builder tags( List<String> tags ) {
             configuration.tags = tags;
+            return this;
+        }
+
+        public Builder href( String s ) {
+            configuration.href = s;
+            return this;
+        }
+
+        public Builder hrefGenerator( Class<? extends TagHrefGenerator> hrefGenerator ) {
+            configuration.hrefGenerator = hrefGenerator;
             return this;
         }
 
@@ -196,6 +210,20 @@ public class TagConfiguration {
 
     public String getAnnotationType() {
         return annotationType;
+    }
+
+    /**
+     * @see com.tngtech.jgiven.annotation.IsTag#href
+     */
+    public String getHref() {
+        return href;
+    }
+
+    /**
+     * @see com.tngtech.jgiven.annotation.IsTag#hrefGenerator
+     */
+    public Class<? extends TagHrefGenerator> getHrefGenerator() {
+        return hrefGenerator;
     }
 
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
@@ -475,6 +475,7 @@ public class ScenarioModelBuilder implements ScenarioListener {
         }
 
         tag.setDescription( getDescriptionFromGenerator( tagConfig, annotation, value ) );
+        tag.setHref( getHref( tagConfig, annotation, value ) );
         return Arrays.asList( tag );
     }
 
@@ -485,7 +486,8 @@ public class ScenarioModelBuilder implements ScenarioListener {
         return TagConfiguration.builder( annotation.annotationType() ).defaultValue( isTag.value() ).description( isTag.description() )
             .explodeArray( isTag.explodeArray() ).ignoreValue( isTag.ignoreValue() ).prependType( isTag.prependType() ).name( name )
             .descriptionGenerator( isTag.descriptionGenerator() ).cssClass( isTag.cssClass() ).color( isTag.color() )
-            .style( isTag.style() ).tags( getTagNames( isTag, annotation ) ).build();
+            .style( isTag.style() ).tags( getTagNames( isTag, annotation ) )
+            .href( isTag.href()).hrefGenerator( isTag.hrefGenerator() ).build();
 
     }
 
@@ -533,12 +535,23 @@ public class ScenarioModelBuilder implements ScenarioListener {
         }
     }
 
+    private String getHref( TagConfiguration tagConfiguration, Annotation annotation, Object value ) {
+        try {
+            return tagConfiguration.getHrefGenerator().newInstance().generateHref( tagConfiguration, annotation, value );
+        } catch( Exception e ) {
+            throw new JGivenWrongUsageException(
+                    "Error while trying to generate the href for annotation " + annotation + " using HrefGenerator class "
+                            + tagConfiguration.getHrefGenerator() + ": " + e.getMessage(), e );
+        }
+    }
+
     private List<Tag> getExplodedTags( Tag originalTag, Object[] values, Annotation annotation, TagConfiguration tagConfig ) {
         List<Tag> result = Lists.newArrayList();
         for( Object singleValue : values ) {
             Tag newTag = originalTag.copy();
             newTag.setValue( String.valueOf( singleValue ) );
             newTag.setDescription( getDescriptionFromGenerator( tagConfig, annotation, singleValue ) );
+            newTag.setHref( getHref( tagConfig, annotation, singleValue ) );
             result.add( newTag );
         }
         return result;

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/tag/DefaultTagHrefGenerator.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/tag/DefaultTagHrefGenerator.java
@@ -1,0 +1,17 @@
+package com.tngtech.jgiven.impl.tag;
+
+import com.tngtech.jgiven.annotation.TagHrefGenerator;
+import com.tngtech.jgiven.config.TagConfiguration;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A default implementation of {@link TagHrefGenerator}.
+ * It just calls {@code tagConfiguration.getHref()}.
+ */
+public class DefaultTagHrefGenerator implements TagHrefGenerator {
+    @Override
+    public String generateHref( TagConfiguration tagConfiguration, Annotation annotation, Object value ) {
+        return tagConfiguration.getHref();
+    }
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/tag/GoToTestHrefGenerator.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/tag/GoToTestHrefGenerator.java
@@ -1,0 +1,26 @@
+package com.tngtech.jgiven.impl.tag;
+
+import com.tngtech.jgiven.annotation.TagHrefGenerator;
+import com.tngtech.jgiven.base.ScenarioTestBase;
+import com.tngtech.jgiven.config.TagConfiguration;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * Implementation of {@link TagHrefGenerator} that creates
+ * an anchor to a specific test.  It expects the {@code value} to be an instanceof ScenarioTestBase
+ */
+public class GoToTestHrefGenerator implements TagHrefGenerator {
+    @Override
+    public String generateHref( TagConfiguration tagConfiguration,
+                                Annotation annotation, Object value ) {
+
+
+        if (value instanceof Class && ScenarioTestBase.class.isAssignableFrom( (Class) value )) {
+            String toLinkTo = ((Class) value).getName();
+            return String.format("#class/%s", toLinkTo );
+        }
+
+        throw new IllegalArgumentException("Object value must extend ScenarioTestBase");
+    }
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/Tag.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/Tag.java
@@ -62,6 +62,12 @@ public class Tag {
      */
     private List<String> tags;
 
+    /**
+     * An optional href used in the HTML report.
+     * Can be {@code null}.
+     */
+    private String href;
+
     public Tag( String type ) {
         this.type = type;
     }
@@ -122,6 +128,14 @@ public class Tag {
 
     public String getStyle() {
         return style;
+    }
+
+    public String getHref() {
+        return href;
+    }
+
+    public void setHref(String href) {
+        this.href = href;
     }
 
     @SuppressWarnings( "unchecked" )
@@ -242,6 +256,7 @@ public class Tag {
         tag.description = this.description;
         tag.prependType = this.prependType;
         tag.tags = this.tags;
+        tag.href = this.href;
         return tag;
     }
 

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/GoToTestHrefGeneratorTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/GoToTestHrefGeneratorTest.java
@@ -1,0 +1,25 @@
+package com.tngtech.jgiven.impl.tag;
+
+import com.tngtech.jgiven.ScenarioRuleTest;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+
+public class GoToTestHrefGeneratorTest {
+
+    private GoToTestHrefGenerator goToTestHrefGenerator = new GoToTestHrefGenerator();
+
+    @Test
+    public void generatesAnchorHrefForTestClass() throws Exception {
+        String generatedHref = goToTestHrefGenerator.generateHref(null, null, ScenarioRuleTest.class);
+        assertThat(generatedHref, is("#class/com.tngtech.jgiven.ScenarioRuleTest"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doesNotWorkWithClassesThatDoNotExtendScenarioTestBase() throws Exception {
+        Class classThatIsNotOfExpectedType = this.getClass();
+        goToTestHrefGenerator.generateHref(null, null, classThatIsNotOfExpectedType);
+    }
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/links/LinkExampleOneTest.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/links/LinkExampleOneTest.java
@@ -1,0 +1,39 @@
+package com.tngtech.jgiven.examples.links;
+
+
+import com.tngtech.jgiven.junit.SimpleScenarioTest;
+import org.junit.Test;
+
+public class LinkExampleOneTest extends SimpleScenarioTest<LinkExampleOneTest.Steps> {
+
+    @SimpleLink
+    @Test
+    public void link_to_fixed_location() {
+        given().test_annotated_with_links();
+        when().the_report_is_generated();
+        then().the_link_appears_in_the_report();
+    }
+
+    @LinkToTest(LinkExampleTwoTest.class)
+    @Test
+    public void link_to_another_test() {
+        given().test_linked_to_another_test();
+        when().the_report_is_generated();
+        then().the_link_appears_in_the_report();
+    }
+
+    public static class Steps {
+        void test_annotated_with_links() {
+        }
+
+        void the_report_is_generated() {
+        }
+
+        void the_link_appears_in_the_report() {
+        }
+
+        void test_linked_to_another_test() {
+        }
+
+    }
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/links/LinkExampleTwoTest.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/links/LinkExampleTwoTest.java
@@ -1,0 +1,17 @@
+package com.tngtech.jgiven.examples.links;
+
+
+import com.tngtech.jgiven.junit.SimpleScenarioTest;
+import org.junit.Test;
+
+public class LinkExampleTwoTest extends SimpleScenarioTest<LinkExampleOneTest.Steps> {
+
+    @LinkToTest(LinkExampleOneTest.class)
+    @Test
+    public void link_to_another_test() {
+        given().test_linked_to_another_test();
+        when().the_report_is_generated();
+        then().the_link_appears_in_the_report();
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/links/LinkToTest.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/links/LinkToTest.java
@@ -1,0 +1,15 @@
+package com.tngtech.jgiven.examples.links;
+
+import com.tngtech.jgiven.annotation.IsTag;
+import com.tngtech.jgiven.base.ScenarioTestBase;
+import com.tngtech.jgiven.impl.tag.GoToTestHrefGenerator;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+
+@IsTag(hrefGenerator = GoToTestHrefGenerator.class)
+@Retention( RetentionPolicy.RUNTIME )
+public @interface LinkToTest {
+    Class<? extends ScenarioTestBase>[] value();
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/links/SimpleLink.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/links/SimpleLink.java
@@ -1,0 +1,14 @@
+package com.tngtech.jgiven.examples.links;
+
+import com.tngtech.jgiven.annotation.IsTag;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+
+
+@IsTag(href="http://www.example.org", description = "Go to example.org")
+@Retention( RetentionPolicy.RUNTIME )
+public @interface SimpleLink {
+
+}

--- a/jgiven-html5-report/src/app/lib/reportCtrl.js
+++ b/jgiven-html5-report/src/app/lib/reportCtrl.js
@@ -537,10 +537,12 @@ jgivenReportApp.controller('JGivenReportCtrl', function ($scope, $rootScope, $do
   };
 
   $scope.getUrlFromTag = function getUrlFromTag (tag) {
+    if(tag.href) {
+      return tag.href;
+    }
     return '#tag/' + getTagName(tag) +
       (tag.value ? '/' + $window.encodeURIComponent(tag.value) : '');
-
-  }
+  };
 
   $scope.getTagByTagId = function (tagId) {
     return tagService.getTagByTagId(tagId);

--- a/jgiven-html5-report/src/app/lib/tagService.js
+++ b/jgiven-html5-report/src/app/lib/tagService.js
@@ -239,6 +239,9 @@ jgivenReportApp.factory('tagService', ['dataService', function (dataService) {
     if (tagInstance.description) {
     	tag.description = tagInstance.description;
     }
+    if (tagInstance.href) {
+      tag.href = tagInstance.href;
+    }
     return tag;
   }
 

--- a/jgiven-html5-report/src/main/java/com/tngtech/jgiven/report/html5/TagFile.java
+++ b/jgiven-html5-report/src/main/java/com/tngtech/jgiven/report/html5/TagFile.java
@@ -14,6 +14,7 @@ public class TagFile {
         String tagType;
         String value;
         String description;
+        String href;
     }
 
     public void fill( Map<String, Tag> tagIdMap ) {
@@ -35,6 +36,12 @@ public class TagFile {
             // for each tag instance separately
             if( !Objects.equal( entry.getValue().getDescription(), tagTypeMap.get( tag.getType() ).getDescription() ) ) {
                 instance.description = entry.getValue().getDescription();
+            }
+
+            // the href might be generated depending on the value, so it must be stored
+            // for each tag instance separately
+            if( !Objects.equal( entry.getValue().getHref(), tagTypeMap.get( tag.getType() ).getHref() ) ) {
+                instance.href = entry.getValue().getHref();
             }
             tags.put( entry.getKey(), instance );
 


### PR DESCRIPTION
I would like to be able to annotate my tests with the class of related tests.

My use case is I have a large number of tests that constitute a larger flow and would like to annotate the code with previous or next and use the annotation to create a link that takes me directly to that test in the html report.

As an enhancement I've added href and hrefGenerator to the tag system, and have modified
the HTML report to link directly to that href if present.

```java
@LinkToTest(LinkExampleTwoTest.class)
@Test
public void link_to_another_test() {
    given().test_linked_to_another_test();
    when().the_report_is_generated();
    then().the_link_appears_in_the_report();
}
```