### PR TITLE
support for camel case in steps (fixes #164)

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
@@ -65,7 +65,7 @@ public class ScenarioModelBuilder implements ScenarioListener {
         if( description.contains( "_" ) ) {
             readableDescription = description.replace( '_', ' ' );
         } else if( !description.contains( " " ) ) {
-            readableDescription = camelCaseToReadableText( description );
+            readableDescription = camelCaseToCapitalizedReadableText( description );
         }
 
         scenarioCaseModel = new ScenarioCaseModel();
@@ -75,9 +75,12 @@ public class ScenarioModelBuilder implements ScenarioListener {
         scenarioModel.setDescription( readableDescription );
     }
 
-    private String camelCaseToReadableText( String camelCase ) {
-        String scenarioDescription = CaseFormat.LOWER_CAMEL.to( CaseFormat.LOWER_UNDERSCORE, camelCase ).replace( '_', ' ' );
-        return WordUtil.capitalize( scenarioDescription );
+    private static String camelCaseToCapitalizedReadableText( String camelCase ) {
+        return WordUtil.capitalize( camelCaseToReadableText( camelCase ) );
+    }
+
+    private static String camelCaseToReadableText(String camelCase) {
+        return CaseFormat.LOWER_CAMEL.to( CaseFormat.LOWER_UNDERSCORE, camelCase ).replace( '_', ' ' );
     }
 
     public void addStepMethod( Method paramMethod, List<NamedArgument> arguments, InvocationMode mode ) {
@@ -250,7 +253,7 @@ public class ScenarioModelBuilder implements ScenarioListener {
             return as.value();
         }
 
-        return nameWithoutUnderlines( paramMethod );
+        return nameWithSpaces( paramMethod );
     }
 
     public void setSuccess( boolean success ) {
@@ -280,8 +283,12 @@ public class ScenarioModelBuilder implements ScenarioListener {
         return stackTrace;
     }
 
-    private static String nameWithoutUnderlines( Method paramMethod ) {
-        return WordUtil.fromSnakeCase( paramMethod.getName() );
+    private static String nameWithSpaces( Method paramMethod ) {
+        String paraMethodName = paramMethod.getName();
+        if( paramMethod.getName().contains( "_" ) ) {
+            return WordUtil.fromSnakeCase( paraMethodName );
+        }
+        return camelCaseToReadableText( paraMethodName );
     }
 
     @Override

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/GivenTestStep.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/GivenTestStep.java
@@ -41,6 +41,12 @@ public class GivenTestStep extends Stage<GivenTestStep> {
         return self();
     }
 
+    public GivenTestStep aStepInCamelCase() {
+        return self();
+    }
+
+
+
     @As( "a step with a bracket after a dollar $]" )
     public GivenTestStep a_step_with_a_bracket_after_a_dollar( int value ) {
         return self();
@@ -55,6 +61,10 @@ public class GivenTestStep extends Stage<GivenTestStep> {
     }
 
     public GivenTestStep a_step_with_a_boolean_$_parameter( @Format( value = BooleanFormatter.class, args = { "yes", "no" } ) boolean b ) {
+        return self();
+    }
+
+    public GivenTestStep aStepInCamelCaseWithA$Parameter( String param ) {
         return self();
     }
 

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ScenarioModelBuilderTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ScenarioModelBuilderTest.java
@@ -269,8 +269,26 @@ public class ScenarioModelBuilderTest extends ScenarioTestBase<GivenTestStep, Wh
     }
 
     @Test
+    public void camel_case_is_supported_in_steps() throws Throwable {
+        startScenario( "Scenario camel case steps" );
+        given().aStepInCamelCase();
+        getScenario().finished();
+        StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
+        assertThat( step.getCompleteSentence() ).isEqualTo( "Given a step in camel case" );
+    }
+
+    @Test
+    public void camel_case_is_supported_in_steps_with_parameters() throws Throwable {
+        startScenario( "Scenario camel case steps with parameter" );
+        given().aStepInCamelCaseWithA$Parameter("dollar");
+        getScenario().finished();
+        StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
+        assertThat( step.getCompleteSentence() ).isEqualTo( "Given a step in camel case with a dollar parameter" );
+    }
+
+    @Test
     public void the_Description_annotation_on_intro_words_is_evaluated() throws Throwable {
-        startScenario( "Scenario with an @As annotaiton" );
+        startScenario( "Scenario with an @As annotation" );
         given().an_intro_word_with_an_as_annotation().something();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();


### PR DESCRIPTION
I followed the same approach as for scenario description. It assumes snake_case if underscore is found. I had to play with the camelCaseToReadableText because we want it capitalised for scenario descriptions but not for steps. :)