### PR TITLE
implemented nested steps #17 (+ text report only)

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/NestedSteps.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/NestedSteps.java
@@ -1,0 +1,9 @@
+package com.tngtech.jgiven.annotation;
+
+import java.lang.annotation.*;
+
+@Documented
+@Retention( RetentionPolicy.RUNTIME )
+@Target( { ElementType.METHOD } )
+public @interface NestedSteps {
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
@@ -103,7 +103,7 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
 
     class MethodHandler implements StepMethodHandler {
         @Override
-        public void handleMethod( Object stageInstance, Method paramMethod, Object[] arguments, InvocationMode mode )
+        public void handleMethod( Object stageInstance, Method paramMethod, Object[] arguments, InvocationMode mode, Method parentMethod )
                 throws Throwable {
 
             if( paramMethod.isSynthetic() && !paramMethod.isBridge() ) {
@@ -124,7 +124,7 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
             }
 
             List<NamedArgument> namedArguments = ParameterNameUtil.mapArgumentsWithParameterNames( paramMethod, Arrays.asList( arguments ) );
-            listener.stepMethodInvoked( paramMethod, namedArguments, mode );
+            listener.stepMethodInvoked( paramMethod, namedArguments, mode, parentMethod );
         }
 
         @Override

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/NoOpScenarioListener.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/NoOpScenarioListener.java
@@ -19,7 +19,7 @@ public class NoOpScenarioListener implements ScenarioListener {
     public void scenarioStarted( Method method, List<NamedArgument> arguments ) {}
 
     @Override
-    public void stepMethodInvoked( Method method, List<NamedArgument> arguments, InvocationMode mode ) {}
+    public void stepMethodInvoked( Method method, List<NamedArgument> arguments, InvocationMode mode, Method parentMethod ) {}
 
     @Override
     public void introWordAdded( String introWord ) {}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/ScenarioListener.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/ScenarioListener.java
@@ -15,7 +15,7 @@ public interface ScenarioListener {
 
     void scenarioStarted( Method method, List<NamedArgument> arguments );
 
-    void stepMethodInvoked( Method method, List<NamedArgument> arguments, InvocationMode mode );
+    void stepMethodInvoked( Method method, List<NamedArgument> arguments, InvocationMode mode, Method parentMethod );
 
     void introWordAdded( String introWord );
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/StepMethodHandler.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/StepMethodHandler.java
@@ -5,7 +5,7 @@ import com.tngtech.jgiven.report.model.InvocationMode;
 import java.lang.reflect.Method;
 
 public interface StepMethodHandler {
-    void handleMethod( Object targetObject, Method paramMethod, Object[] arguments, InvocationMode mode )
+    void handleMethod( Object targetObject, Method paramMethod, Object[] arguments, InvocationMode mode, Method parentMethod )
             throws Throwable;
 
     void handleThrowable( Throwable t ) throws Throwable;

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/InvocationMode.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/InvocationMode.java
@@ -1,9 +1,8 @@
 package com.tngtech.jgiven.report.model;
 
-import com.tngtech.jgiven.report.model.StepStatus;
-
 public enum InvocationMode {
     NORMAL,
+    NESTED,
     FAILED,
     SKIPPED,
     PENDING,
@@ -19,6 +18,8 @@ public enum InvocationMode {
                 return StepStatus.PENDING;
             case SKIPPED:
                 return StepStatus.SKIPPED;
+            case NESTED:
+                return StepStatus.NESTED;
             default:
                 throw new IllegalArgumentException( this.toString() );
         }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/StepModel.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/StepModel.java
@@ -1,12 +1,13 @@
 package com.tngtech.jgiven.report.model;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.tngtech.jgiven.attachment.Attachment;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
-import com.tngtech.jgiven.attachment.Attachment;
 
 public class StepModel {
     /**
@@ -18,6 +19,11 @@ public class StepModel {
      * All words of this step including the introduction word.
      */
     public List<Word> words = Lists.newArrayList();
+
+    /**
+     * Nested steps
+     */
+    public List<StepModel> nestedSteps = Lists.newArrayList();
 
     /**
      * The execution status of this step.
@@ -97,7 +103,7 @@ public class StepModel {
     }
 
     public boolean hasExtendedDescription() {
-        return extendedDescription != null;
+        return extendedDescription != null || Iterables.size( nestedSteps ) > 0;
     }
 
     public void setExtendedDescription( String extendedDescription ) {
@@ -124,5 +130,13 @@ public class StepModel {
 
     public AttachmentModel getAttachment() {
         return attachment;
+    }
+
+    public boolean hasNestedSteps() {
+        return Iterables.size( nestedSteps ) > 0;
+    }
+
+    public void addNestedStep( StepModel stepModel ) {
+        nestedSteps.add( stepModel );
     }
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/StepStatus.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/StepStatus.java
@@ -2,6 +2,7 @@ package com.tngtech.jgiven.report.model;
 
 public enum StepStatus {
     PASSED,
+    NESTED,
     FAILED,
     SKIPPED,
     PENDING;

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/text/PlainTextScenarioWriter.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/text/PlainTextScenarioWriter.java
@@ -1,23 +1,25 @@
 package com.tngtech.jgiven.report.text;
 
-import static org.fusesource.jansi.Ansi.Attribute.INTENSITY_BOLD;
-import static org.fusesource.jansi.Ansi.Color.MAGENTA;
-
-import java.io.PrintWriter;
-import java.util.List;
-
-import org.fusesource.jansi.Ansi.Attribute;
-import org.fusesource.jansi.Ansi.Color;
-
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.tngtech.jgiven.impl.params.DefaultCaseDescriptionProvider;
 import com.tngtech.jgiven.impl.util.WordUtil;
 import com.tngtech.jgiven.report.model.*;
+import org.fusesource.jansi.Ansi.Attribute;
+import org.fusesource.jansi.Ansi.Color;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+import static org.fusesource.jansi.Ansi.Attribute.INTENSITY_BOLD;
+import static org.fusesource.jansi.Ansi.Color.MAGENTA;
 
 public class PlainTextScenarioWriter extends PlainTextWriter {
     private static final String INDENT = "   ";
+    public static final String NESTED_HEADING = "\\-- ";
+    public static final String NESTED_INDENT = "| ";
 
     protected ScenarioModel currentScenarioModel;
     protected ScenarioCaseModel currentCaseModel;
@@ -100,6 +102,8 @@ public class PlainTextScenarioWriter extends PlainTextWriter {
             intro = INDENT + String.format( "%" + maxFillWordLength + "s ", " " );
         }
 
+
+
         int restSize = words.size();
         boolean printDataTable = false;
         if( words.size() > 1 ) {
@@ -122,10 +126,33 @@ public class PlainTextScenarioWriter extends PlainTextWriter {
         }
         writer.println( intro + rest );
 
+        printNestedSteps( stepModel, 0 );
+
         if( printDataTable ) {
             writer.println();
             printDataTable( words.get( words.size() - 1 ) );
         }
+    }
+
+    private void printNestedSteps(StepModel stepModel, int depth) {
+        if( stepModel.hasNestedSteps() ) {
+            for( StepModel nestedStepModel: stepModel.nestedSteps ) {
+                writer.println(INDENT + INDENT + INDENT + Strings.repeat( NESTED_INDENT , depth ) + NESTED_HEADING + getNestedStepString(nestedStepModel));
+                printNestedSteps( nestedStepModel, depth + 1) ;
+            }
+        }
+    }
+
+    private String getNestedStepString(StepModel nestedStepModel) {
+        StringBuilder stringBuilder = new StringBuilder();
+        if( nestedStepModel.words.get(0).isIntroWord() ) {
+            stringBuilder.append(WordUtil.capitalize(nestedStepModel.words.get(0).getValue()));
+            stringBuilder.append(" ").append(joinWords(nestedStepModel.words.subList(1, nestedStepModel.words.size())));
+        }
+        else {
+            stringBuilder.append(joinWords(nestedStepModel.words));
+        }
+        return stringBuilder.toString();
     }
 
     private void printDataTable( Word word ) {

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/GivenTestStep.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/GivenTestStep.java
@@ -32,6 +32,33 @@ public class GivenTestStep extends Stage<GivenTestStep> {
         return self();
     }
 
+    public GivenTestStep something_further() {
+        return self();
+    }
+
+    public GivenTestStep something_else_that_fails() {
+        if( 1 == 1 ) {
+            throw new RuntimeException("failure");
+        }
+        return self();
+    }
+
+    @NestedSteps
+    public GivenTestStep something_with_nested_steps() {
+        return given().something().and().something_else();
+    }
+
+    @NestedSteps
+    public GivenTestStep something_with_multilevel_nested_steps() {
+        return given().something_with_nested_steps().and().something_further();
+    }
+
+    @NestedSteps
+    public GivenTestStep something_with_nested_steps_that_fails() {
+        return given().something().and().something_else_that_fails();
+    }
+
+
     public GivenTestStep an_array( Object argument ) {
         return self();
     }

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/report/text/PlainTextReporterTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/report/text/PlainTextReporterTest.java
@@ -103,6 +103,83 @@ public class PlainTextReporterTest extends ScenarioTestBase<GivenTestStep, WhenT
     }
 
     @Test
+    public void nested_steps_are_displayed_in_the_report() throws UnsupportedEncodingException {
+        getScenario().startScenario( "test" );
+
+        given().something_with_nested_steps();
+
+        when().something_happens();
+
+        then().something_has_happen()
+                .something_else_not();
+
+        String string = PlainTextReporter.toString( getScenario().getScenarioModel() );
+        assertThat( string.replaceAll( System.getProperty( "line.separator" ), "\n" ) )
+                .contains( ""
+                                + " Scenario: Test\n"
+                                + "\n"
+                                + "   Given something with nested steps\n"
+                                + "         \\-- Given something\n"
+                                + "         \\-- And something else\n"
+                                + "    When something happens\n"
+                                + "    Then something has happen\n"
+                                + "         something else not"
+                );
+    }
+
+    @Test
+    public void multilevel_nested_steps_are_displayed_in_the_report() throws UnsupportedEncodingException {
+        getScenario().startScenario( "test" );
+
+        given().something_with_multilevel_nested_steps();
+
+        when().something_happens();
+
+        then().something_has_happen()
+                .something_else_not();
+
+        String string = PlainTextReporter.toString( getScenario().getScenarioModel() );
+        assertThat( string.replaceAll( System.getProperty( "line.separator" ), "\n" ) )
+                .contains( ""
+                                + " Scenario: Test\n"
+                                + "\n"
+                                + "   Given something with multilevel nested steps\n"
+                                + "         \\-- Given something with nested steps\n"
+                                + "         | \\-- Given something\n"
+                                + "         | \\-- And something else\n"
+                                + "         \\-- And something further\n"
+                                + "    When something happens\n"
+                                + "    Then something has happen\n"
+                                + "         something else not"
+                );
+    }
+
+    @Test
+    public void nested_step_failures_appear_in_the_top_level_enclosing_step() throws UnsupportedEncodingException {
+        getScenario().startScenario( "test" );
+
+        given().something_with_nested_steps_that_fails();
+
+        when().something_happens();
+
+        then().something_has_happen()
+                .something_else_not();
+
+        String string = PlainTextReporter.toString( getScenario().getScenarioModel() );
+        assertThat( string.replaceAll( System.getProperty( "line.separator" ), "\n" ) )
+                .contains( ""
+                                + " Scenario: Test\n"
+                                + "\n"
+                                + "   Given something with nested steps that fails (failed)\n"
+                                + "         \\-- Given something\n"
+                                + "         \\-- And something else that fails\n"
+                                + "    When something happens (skipped)\n"
+                                + "    Then something has happen (skipped)\n"
+                                + "         something else not (skipped)"
+                );
+    }
+
+    @Test
     public void parameters_are_correctly_replaced_if_there_is_an_intro_word() throws UnsupportedEncodingException {
         getScenario().startScenario( "test" );
         GivenTestStep stage = getScenario().addStage( GivenTestStep.class );

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/nested/NestedStepsTest.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/nested/NestedStepsTest.java
@@ -1,0 +1,88 @@
+package com.tngtech.jgiven.examples.nested;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.NestedSteps;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.junit.SimpleScenarioTest;
+import org.junit.Test;
+import org.testng.Assert;
+
+public class NestedStepsTest extends SimpleScenarioTest<NestedStepsTest.NestedStage> {
+
+
+    @Test
+    public void aTestWithNestedSteps() {
+
+        given().I_fill_out_the_registration_form_with_valid_values();
+
+        when().I_submit_the_form();
+
+        then().the_password_matches();
+
+    }
+
+
+    static class NestedStage extends Stage<NestedStage> {
+
+        @ProvidedScenarioState
+        String name;
+
+        @ProvidedScenarioState
+        String email;
+
+        @ProvidedScenarioState
+        String password;
+
+        @ProvidedScenarioState
+        String repeatedPassword;
+
+        @NestedSteps
+        public NestedStage I_fill_out_the_registration_form_with_valid_values() {
+            return I_enter_a_name("Franky")
+                    .and().I_enter_a_email_address("franky@acme.com")
+                    .and().I_enter_a_password("password1234")
+                    .and().I_enter_a_repeated_password("password1234");
+        }
+
+        @NestedSteps
+        public NestedStage I_enter_a_name(String name) {
+            return I_think_a_name(name).and().I_write_the_name(name);
+        }
+
+        public NestedStage I_think_a_name(String name) {
+            return self();
+        }
+
+        public NestedStage I_write_the_name(String name) {
+            this.name = name;
+            return self();
+        }
+
+        public NestedStage I_enter_a_email_address(String email) {
+            this.email = email;
+            return self();
+        }
+
+        public NestedStage I_enter_a_password(String password) {
+            this.password = password;
+            return self();
+        }
+
+        public NestedStage I_enter_a_repeated_password(String repeatedPassword) {
+            this.repeatedPassword = repeatedPassword;
+            return self();
+        }
+
+        public NestedStage I_submit_the_form() {
+            return self();
+        }
+
+        public NestedStage the_password_matches() {
+            Assert.assertEquals(password, repeatedPassword);
+            return self();
+        }
+
+    }
+
+
+}


### PR DESCRIPTION
Hello, this is an attempt to support nested steps.

I had to change a few things around ScenarioModelBuilder to keep a stack of steps so we can add a nested step to the right parent and supporting multilevel nesting. 

As for the report, I have just done it for the plain text report. Note that the nested steps are for report purposes only, i.e. the step status, duration, attachments, etc, are really kept at the top level only. Otherwise it gets too complicated.
If this is accepted, a separate issue should be created for html5 report maybe with a collapsible widget

