### PR TITLE
ensure that contents are encoded utf-8 for pako lib

### DIFF
--- a/jgiven-html5-report/src/main/java/com/tngtech/jgiven/report/html5/Html5ReportGenerator.java
+++ b/jgiven-html5-report/src/main/java/com/tngtech/jgiven/report/html5/Html5ReportGenerator.java
@@ -158,7 +158,8 @@ public class Html5ReportGenerator extends AbstractReportGenerator {
 
             try {
                 this.byteStream = new ByteArrayOutputStream();
-                this.contentStream = new PrintStream( new GZIPOutputStream( byteStream ) );
+                // pako client side library expects byte stream to be UTF-8 encoded
+                this.contentStream = new PrintStream( new GZIPOutputStream( byteStream ), false, "utf-8" );
                 this.contentStream.append( "{\"scenarios\":[" );
 
                 this.fileStream = new PrintStream( new FileOutputStream( targetFile ), false, "utf-8" );


### PR DESCRIPTION
This occurs when running on an OS without UTF-8 as default charset (i.e. windows machines). This problem has been introduced in #186. 
I found it hard to provide an automated test for this. Therefore I looked at JGiven's own report before and after regarding the German test cases. 
Please double-check if this still works on UTF-8 (well, it should, shouldn't it?)