### PR TITLE
#203 ( #202 ) implemented ComposedScenarioStage to inject scenario st…

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/ComposedScenarioStage.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/ComposedScenarioStage.java
@@ -1,0 +1,17 @@
+package com.tngtech.jgiven.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks fields to be read and/or written by a scenario stage.
+ */
+@Documented
+@Retention( RetentionPolicy.RUNTIME )
+@Target( ElementType.FIELD )
+public @interface ComposedScenarioStage {
+
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioExecutor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioExecutor.java
@@ -9,6 +9,8 @@ import com.tngtech.jgiven.report.model.NamedArgument;
 
 public interface ScenarioExecutor {
 
+    static final int INITIAL_MAX_STEP_DEPTH = 1;
+
     public enum State {
         INIT,
         STARTED,

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StackElement.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StackElement.java
@@ -1,8 +1,39 @@
 package com.tngtech.jgiven.impl;
 
-/**
- * Created by albertofaci on 11/05/2016.
- */
+import com.google.common.collect.Sets;
+
+import com.tngtech.jgiven.annotation.NestedSteps;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+
+
 public class StackElement {
+
+    private final Object receiver;
+    private final Method method;
+    private final Set<Class<?>> composedStages;
+
+    public StackElement(Object receiver, Method method, Set<Class<?>> composedStages) {
+        this.method = method;
+        this.receiver = receiver;
+        this.composedStages = composedStages;
+    }
+
+    public Object getReceiver() {
+        return receiver;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public boolean isNestedMethod() {
+        return method.isAnnotationPresent(NestedSteps.class);
+    }
+
+    public Set<Class<?>> getComposedStages() {
+        return Sets.newHashSet(composedStages);
+    }
 
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StackElement.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StackElement.java
@@ -1,0 +1,8 @@
+package com.tngtech.jgiven.impl;
+
+/**
+ * Created by albertofaci on 11/05/2016.
+ */
+public class StackElement {
+
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
@@ -391,7 +391,7 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
     @Override
     @SuppressWarnings( "unchecked" )
     public void injectSteps( Object stage ) {
-        for( Field field : FieldCache.get( stage.getClass() ).getFieldsWithAnnotation( ScenarioStage.class ) ) {
+        for( Field field : FieldCache.get( stage.getClass() ).getFieldsWithAnnotation( ScenarioStage.class, ComposedScenarioStage.class ) ) {
             Object steps = addStage( field.getType() );
             ReflectionUtil.setField( field, stage, steps, ", annotated with @ScenarioStage" );
         }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
@@ -11,7 +11,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Stack;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,10 +56,12 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
     private boolean executeLifeCycleMethods = true;
 
     /**
-     * Measures the stack depth of methods called on the step definition object.
-     * Only the top-level method calls are used for reporting.
+     * Contains the stack of calls. Only top level and @NestedSteps children
+     * are used for reporting
+     * Only top-level @ScenarioStage and any nested @ComponentScenarioStage
+     * are used to update the context
      */
-    protected final AtomicInteger stackDepth = new AtomicInteger();
+    protected final Stack<StackElement> stack = new Stack<StackElement>();
 
     protected final Map<Class<?>, StageState> stages = Maps.newLinkedHashMap();
 
@@ -68,7 +70,7 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
     private final ValueInjector injector = new ValueInjector();
     private ScenarioListener listener = new NoOpScenarioListener();
     protected final StepMethodHandler methodHandler = new MethodHandler();
-    private final StandaloneStepMethodInterceptor methodInterceptor = new StandaloneStepMethodInterceptor( methodHandler, stackDepth );
+    private final StandaloneStepMethodInterceptor methodInterceptor = new StandaloneStepMethodInterceptor(methodHandler, stack);
     private Throwable failedException;
     private boolean failIfPass;
     private boolean suppressExceptions;
@@ -123,8 +125,31 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
                 return;
             }
 
+            if(stack.size() > INITIAL_MAX_STEP_DEPTH && !nestedStepsActiveInStack() ) {
+                return;
+            }
+
             List<NamedArgument> namedArguments = ParameterNameUtil.mapArgumentsWithParameterNames( paramMethod, Arrays.asList( arguments ) );
             listener.stepMethodInvoked( paramMethod, namedArguments, mode, hasNestedSteps );
+        }
+
+        private boolean nestedStepsActiveInStack() {
+            if(stack.empty()) {
+                return false;
+            }
+            if(stack.peek().isNestedMethod()) {
+                return true;
+            }
+            StackElement top = stack.pop();
+            try {
+                if(stack.empty()) {
+                    return false;
+                }
+                return stack.peek().isNestedMethod();
+            }
+            finally {
+                stack.push(top);
+            }
         }
 
         @Override
@@ -190,8 +215,6 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
 
     private <T> T update( T t ) throws Throwable {
         if( currentStage == t ) { // NOSONAR: reference comparison OK here
-            readScenarioState( currentStage );
-            updateScenarioState( currentStage );
             return t;
         }
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
@@ -189,6 +189,11 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
     }
 
     private <T> T update( T t ) throws Throwable {
+        if( currentStage == t ) { // NOSONAR: reference comparison OK here
+            readScenarioState( currentStage );
+            updateScenarioState( currentStage );
+            return t;
+        }
 
         if( currentStage == null ) {
             ensureBeforeStepsAreExecuted();
@@ -197,7 +202,7 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
             readScenarioState( currentStage );
         }
 
-        injector.updateValues( t );
+        updateScenarioState( t );
 
         StageState stageState = getStageState( t );
         if( !stageState.beforeStageCalled ) {
@@ -207,6 +212,10 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
 
         currentStage = t;
         return t;
+    }
+
+    private <T> void updateScenarioState( T t ) {
+        injector.updateValues( t );
     }
 
     private void executeAfterStageMethods( Object stage ) throws Throwable {

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
@@ -189,9 +189,6 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
     }
 
     private <T> T update( T t ) throws Throwable {
-        if( currentStage == t ) { // NOSONAR: reference comparison OK here
-            return t;
-        }
 
         if( currentStage == null ) {
             ensureBeforeStepsAreExecuted();

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/StandaloneStepMethodInterceptor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/StandaloneStepMethodInterceptor.java
@@ -1,7 +1,9 @@
 package com.tngtech.jgiven.impl.intercept;
 
+import com.tngtech.jgiven.impl.StackElement;
+
 import java.lang.reflect.Method;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Stack;
 
 import net.sf.cglib.proxy.MethodInterceptor;
 import net.sf.cglib.proxy.MethodProxy;
@@ -13,8 +15,8 @@ import net.sf.cglib.proxy.MethodProxy;
 public class StandaloneStepMethodInterceptor extends StepMethodInterceptor implements MethodInterceptor {
 
     public StandaloneStepMethodInterceptor(
-            StepMethodHandler scenarioMethodHandler, AtomicInteger stackDepth) {
-        super(scenarioMethodHandler, stackDepth);
+        StepMethodHandler scenarioMethodHandler, Stack<StackElement> stack) {
+        super(scenarioMethodHandler, stack);
     }
 
     @Override

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/GivenTestComposedStep.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/GivenTestComposedStep.java
@@ -1,0 +1,15 @@
+package com.tngtech.jgiven;
+
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+
+public class GivenTestComposedStep extends Stage<GivenTestComposedStep> {
+
+    @ProvidedScenarioState
+    int value3;
+
+    public void some_integer_value_in_the_substep( int someIntValue ) {
+        this.value3 = someIntValue;
+    }
+
+
+}

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/GivenTestStep.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/GivenTestStep.java
@@ -11,12 +11,19 @@ public class GivenTestStep extends Stage<GivenTestStep> {
     @ProvidedScenarioState
     int value2;
 
+    @ComposedScenarioStage
+    GivenTestComposedStep givenTestComposedStep;
+
     public void some_integer_value( int someIntValue ) {
         this.value1 = someIntValue;
     }
 
     public void another_integer_value( int anotherValue ) {
         this.value2 = anotherValue;
+    }
+
+    public void an_integer_value_set_in_a_substep ( int substepValue ) {
+        givenTestComposedStep.some_integer_value_in_the_substep(substepValue );
     }
 
     public void $d_and_$d( int value1, int value2 ) {

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/ThenTestComposedStep.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/ThenTestComposedStep.java
@@ -1,0 +1,16 @@
+package com.tngtech.jgiven;
+
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThenTestComposedStep extends Stage<ThenTestComposedStep> {
+
+    @ExpectedScenarioState
+    int value3;
+
+    public ThenTestComposedStep the_substep_value_is(int expected) {
+        assertThat( value3 ).isEqualTo( expected );
+        return self();
+    }
+}

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/ThenTestStep.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/ThenTestStep.java
@@ -4,10 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.tngtech.jgiven.annotation.ExpectedScenarioState;
 import com.tngtech.jgiven.annotation.Pending;
+import com.tngtech.jgiven.annotation.ComposedScenarioStage;
 
 public class ThenTestStep extends Stage<ThenTestStep> {
+
     @ExpectedScenarioState
     int intResult;
+
+    @ComposedScenarioStage
+    ThenTestComposedStep thenTestComposedStep;
+
+    @ExpectedScenarioState
+    int value3;
 
     public void sms_and_emails_exist() {}
 
@@ -22,6 +30,16 @@ public class ThenTestStep extends Stage<ThenTestStep> {
 
     @Pending
     public ThenTestStep something_else_not() {
+        return self();
+    }
+
+    public ThenTestStep the_substep_value_is(int expected) {
+        thenTestComposedStep.the_substep_value_is(expected);
+        return self();
+    }
+
+    public ThenTestStep the_substep_value_referred_in_the_step_is(int expected) {
+        assertThat( value3 ).isEqualTo( expected );
         return self();
     }
 }

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/report/text/PlainTextReporterTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/report/text/PlainTextReporterTest.java
@@ -276,4 +276,24 @@ public class PlainTextReporterTest extends ScenarioTestBase<GivenTestStep, WhenT
         assertThat( string ).contains( "quoted \"foo\" test" );
     }
 
+    @Test
+    public void substeps_access_are_not_printed_in_report() throws UnsupportedEncodingException {
+        getScenario().startScenario( "substeps" );
+
+        given().an_integer_value_set_in_a_substep(4);
+        when().something_happens();
+        then().the_substep_value_is(4)
+            .and().the_substep_value_referred_in_the_step_is(4);
+;
+        String string = PlainTextReporter.toString( getScenario().getScenarioModel() );
+
+        assertThat( string.replaceAll( System.getProperty( "line.separator" ), "\n" ) )
+            .contains(
+                         "   Given an integer value set in a substep 4\n"
+                       + "    When something happens\n"
+                       + "    Then the substep value is 4\n"
+                       + "     And the substep value referred in the step is 4"
+            );
+    }
+
 }

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/injection/ComposedStepInjectionTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/injection/ComposedStepInjectionTest.java
@@ -1,0 +1,90 @@
+package com.tngtech.jgiven.junit.injection;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.annotation.ScenarioStage;
+import com.tngtech.jgiven.annotation.ScenarioState;
+import com.tngtech.jgiven.annotation.ComposedScenarioStage;
+import com.tngtech.jgiven.junit.ScenarioTest;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ComposedStepInjectionTest extends ScenarioTest {
+
+    @ScenarioStage
+    CustomerSteps customerSteps;
+
+    @ScenarioStage
+    ThenCustomer thenCustomer;
+
+    @Test
+    public void substeps_are_injected_into_test_case() {
+        customerSteps.given().a_customer();
+        thenCustomer.then().the_site_language_is("de-DE");
+    }
+
+
+    static class CustomerSteps extends Stage<CustomerSteps> {
+
+        @ProvidedScenarioState
+        Customer customer;
+
+        @ComposedScenarioStage
+        LanguageSteps languageSteps;
+
+        public CustomerSteps a_customer() {
+            customer = new Customer();
+            languageSteps.the_site_language_is_set_to("de-DE");
+            return self();
+        }
+
+    }
+
+    static class LanguageSteps extends Stage<LanguageSteps> {
+
+        @ScenarioState
+        String language;
+
+        public LanguageSteps the_site_language_is_set_to(String language) {
+            this.language = language;
+            return this;
+        }
+
+    }
+
+    static class ThenCustomer extends Stage<ThenCustomer> {
+
+        @ExpectedScenarioState
+        String language;
+
+        @ComposedScenarioStage
+        LanguageSteps languageSteps;
+
+        @ComposedScenarioStage
+        OtherLanguageSteps otherLanguageSteps;
+
+
+        public ThenCustomer the_site_language_is(String expectedLanguage) {
+            assertThat(language).isEqualTo(expectedLanguage);
+            assertThat(languageSteps.language).isEqualTo(expectedLanguage);
+            assertThat(otherLanguageSteps.language).isEqualTo(expectedLanguage);
+
+            return self();
+        }
+
+    }
+
+    static class OtherLanguageSteps extends Stage<OtherLanguageSteps> {
+
+        @ExpectedScenarioState
+        String language;
+
+    }
+
+    static class Customer {
+    }
+
+}

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/injection/ComposedStepInjectionTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/injection/ComposedStepInjectionTest.java
@@ -22,22 +22,26 @@ public class ComposedStepInjectionTest extends ScenarioTest {
 
     @Test
     public void substeps_are_injected_into_test_case() {
-        customerSteps.given().a_customer();
-        thenCustomer.then().the_site_language_is("de-DE");
+        customerSteps.given().a_customer().the_default_language();
+        thenCustomer.then().the_site_language_is( "de-DE" );
     }
 
 
     static class CustomerSteps extends Stage<CustomerSteps> {
 
-        @ProvidedScenarioState
-        Customer customer;
-
         @ComposedScenarioStage
         LanguageSteps languageSteps;
 
+        @ScenarioState
+        String language;
+
         public CustomerSteps a_customer() {
-            customer = new Customer();
-            languageSteps.the_site_language_is_set_to("de-DE");
+            languageSteps.the_site_language_is_set_to( "de-DE" );
+            return self();
+        }
+
+        public CustomerSteps the_default_language() {
+            assertThat(language).isEqualTo( "de-DE" );
             return self();
         }
 
@@ -48,7 +52,7 @@ public class ComposedStepInjectionTest extends ScenarioTest {
         @ScenarioState
         String language;
 
-        public LanguageSteps the_site_language_is_set_to(String language) {
+        public LanguageSteps the_site_language_is_set_to( String language ) {
             this.language = language;
             return this;
         }
@@ -67,10 +71,10 @@ public class ComposedStepInjectionTest extends ScenarioTest {
         OtherLanguageSteps otherLanguageSteps;
 
 
-        public ThenCustomer the_site_language_is(String expectedLanguage) {
-            assertThat(language).isEqualTo(expectedLanguage);
-            assertThat(languageSteps.language).isEqualTo(expectedLanguage);
-            assertThat(otherLanguageSteps.language).isEqualTo(expectedLanguage);
+        public ThenCustomer the_site_language_is( String expectedLanguage) {
+            assertThat( language ).isEqualTo( expectedLanguage );
+            assertThat( languageSteps.language ).isEqualTo( expectedLanguage );
+            assertThat( otherLanguageSteps.language ).isEqualTo (expectedLanguage );
 
             return self();
         }
@@ -84,7 +88,5 @@ public class ComposedStepInjectionTest extends ScenarioTest {
 
     }
 
-    static class Customer {
-    }
 
 }

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/injection/ComposedStepInjectionTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/injection/ComposedStepInjectionTest.java
@@ -2,7 +2,6 @@ package com.tngtech.jgiven.junit.injection;
 
 import com.tngtech.jgiven.Stage;
 import com.tngtech.jgiven.annotation.ExpectedScenarioState;
-import com.tngtech.jgiven.annotation.ProvidedScenarioState;
 import com.tngtech.jgiven.annotation.ScenarioStage;
 import com.tngtech.jgiven.annotation.ScenarioState;
 import com.tngtech.jgiven.annotation.ComposedScenarioStage;
@@ -22,8 +21,11 @@ public class ComposedStepInjectionTest extends ScenarioTest {
 
     @Test
     public void substeps_are_injected_into_test_case() {
-        customerSteps.given().a_customer().the_default_language();
-        thenCustomer.then().the_site_language_is( "de-DE" );
+        customerSteps.given().a_customer()
+            .and().the_default_language_is_set()
+            .and().the_default_colour_is_set();
+        thenCustomer.then().the_site_language_is( "de-DE" )
+            .and().the_site_color_is( "Red" );
     }
 
 
@@ -32,16 +34,28 @@ public class ComposedStepInjectionTest extends ScenarioTest {
         @ComposedScenarioStage
         LanguageSteps languageSteps;
 
+        @ComposedScenarioStage
+        ColorSteps colorSteps;
+
         @ScenarioState
         String language;
 
+        @ScenarioState
+        String color;
+
         public CustomerSteps a_customer() {
             languageSteps.the_site_language_is_set_to( "de-DE" );
+            colorSteps.the_site_color_is_set_to( "Red" );
             return self();
         }
 
-        public CustomerSteps the_default_language() {
-            assertThat(language).isEqualTo( "de-DE" );
+        public CustomerSteps the_default_language_is_set() {
+            assertThat( language ).isEqualTo( "de-DE" );
+            return self();
+        }
+
+        public CustomerSteps the_default_colour_is_set() {
+            assertThat( color ).isEqualTo( "Red" );
             return self();
         }
 
@@ -59,6 +73,18 @@ public class ComposedStepInjectionTest extends ScenarioTest {
 
     }
 
+    static class ColorSteps extends Stage<ColorSteps> {
+
+        @ScenarioState
+        String color;
+
+        public ColorSteps the_site_color_is_set_to( String color ) {
+            this.color = color;
+            return this;
+        }
+
+    }
+
     static class ThenCustomer extends Stage<ThenCustomer> {
 
         @ExpectedScenarioState
@@ -70,6 +96,9 @@ public class ComposedStepInjectionTest extends ScenarioTest {
         @ComposedScenarioStage
         OtherLanguageSteps otherLanguageSteps;
 
+        @ExpectedScenarioState
+        String color;
+
 
         public ThenCustomer the_site_language_is( String expectedLanguage) {
             assertThat( language ).isEqualTo( expectedLanguage );
@@ -79,6 +108,10 @@ public class ComposedStepInjectionTest extends ScenarioTest {
             return self();
         }
 
+        public ThenCustomer the_site_color_is( String expectedSiteColor ) {
+            assertThat( color ).isEqualTo( expectedSiteColor );
+            return self();
+        }
     }
 
     static class OtherLanguageSteps extends Stage<OtherLanguageSteps> {

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/injection/MultilevelComposedStepInjectionTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/injection/MultilevelComposedStepInjectionTest.java
@@ -1,0 +1,93 @@
+package com.tngtech.jgiven.junit.injection;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ComposedScenarioStage;
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.annotation.ScenarioStage;
+import com.tngtech.jgiven.annotation.ScenarioState;
+import com.tngtech.jgiven.junit.ScenarioTest;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MultilevelComposedStepInjectionTest extends ScenarioTest {
+
+    @ScenarioStage
+    CustomerSteps customerSteps;
+
+    @ScenarioStage
+    ThenCustomer thenCustomer;
+
+    @Test
+    public void substeps_are_injected_into_test_case() {
+        customerSteps.given().a_customer();
+        thenCustomer.then().the_site_language_is( "de-DE" );
+    }
+
+
+    static class CustomerSteps extends Stage<CustomerSteps> {
+
+        @ComposedScenarioStage
+        LanguageSteps languageSteps;
+
+        public CustomerSteps a_customer() {
+            languageSteps.the_site_language_is_set_to( "de-DE" );
+            return self();
+        }
+
+    }
+
+    static class LanguageSteps extends Stage<LanguageSteps> {
+
+
+        @ComposedScenarioStage
+        OtherLanguageSteps otherLanguageSteps;
+
+        public LanguageSteps the_site_language_is_set_to( String language ) {
+            otherLanguageSteps.the_site_language_is_set_to( language );
+            return this;
+        }
+
+    }
+
+    static class ThenCustomer extends Stage<ThenCustomer> {
+
+        @ExpectedScenarioState
+        String language;
+
+        @ComposedScenarioStage
+        LanguageSteps languageSteps;
+
+        @ComposedScenarioStage
+        OtherLanguageSteps otherLanguageSteps;
+
+
+        public ThenCustomer the_site_language_is( String expectedLanguage ) {
+            assertThat( language ).isEqualTo( expectedLanguage );
+            assertThat( languageSteps.otherLanguageSteps.language ).isEqualTo( expectedLanguage );
+            assertThat( otherLanguageSteps.language ).isEqualTo( expectedLanguage );
+
+            return self();
+        }
+
+    }
+
+    static class OtherLanguageSteps extends Stage<OtherLanguageSteps> {
+
+        @ExpectedScenarioState
+        String language;
+
+        public OtherLanguageSteps the_site_language_is_set_to(String language) {
+            this.language = language;
+            return this;
+        }
+
+
+    }
+
+    static class Customer {
+    }
+
+}

--- a/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/SpringScenarioExecutor.java
+++ b/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/SpringScenarioExecutor.java
@@ -45,7 +45,7 @@ public class SpringScenarioExecutor extends StandaloneScenarioExecutor implement
                 if (advisor.getAdvice() instanceof SpringStepMethodInterceptor ) {
                     SpringStepMethodInterceptor interceptor = (SpringStepMethodInterceptor)advisor.getAdvice();
                     interceptor.setScenarioMethodHandler(this.methodHandler);
-                    interceptor.setStackDepth(this.stackDepth);
+                    interceptor.setStack(this.stack);
                     interceptor.enableMethodHandling(true);
                 }
             }

--- a/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/SpringStepMethodInterceptor.java
+++ b/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/SpringStepMethodInterceptor.java
@@ -42,7 +42,7 @@ public class SpringStepMethodInterceptor extends StepMethodInterceptor implement
                 return invocation.proceed();
             }
         };
-        if (getScenarioMethodHandler() == null || getStackDepth() == null) {
+        if (getScenarioMethodHandler() == null || getStack() == null) {
             return invoker.proceed(); // not running in JGiven context
         }
         return doIntercept(receiver, method, parameters, invoker);


### PR DESCRIPTION
This implements the `ComposedScenarioStage` annotation, an attempt to be able to inject stages within stages. Tickets #202 and #203.  Just a couple of tweaks in the `ValueInjector` class and job done.

- The composed stages are resolved by type (effectively singletons within the JGiven dependency injection framework). Otherwise we could have variables defined with `@ScenarioState` and bound by name that wouldn't be bound because the containing composed scenarios state are different instances of the same type (it's a bit confusing)

- Nested composed stages are supported and this updates the `stackDepth`.

- The report only displays the top-level stage method call (Although it plays well with `@NestedSteps`)

- `@ScenarioState` fields are updated and can be access from any stage (composed or not)

To solve the example in the ticket

```
public class MyFeatureSteps extends Stage<MyFeatureSteps>{  

    @ComposedScenarioStage
    LoginSteps loginSteps;

    @ExpectedScenarioState
    int newUserId; //The newUserId is now injected here :)


    public GivenLessomplanSteps a_new_user() {
        loginSteps.a_new_user();
        return self();
    }

    public GivenLessomplanSteps the_user_sets_up_my_feature(){
            FeatureFactory.setUp(newUserId);
    }
}   
public Class LoginSteps extends Stage<LoginSteps>{

    @ProvidedScenarioState
    int newUserId;

    public LoginSteps a_new_user() {

        newUserId = LoginService.myLoginMethod();   
        return self();
    }       
}
```

Please let me know if the approach is alright or any comments
