### PR TITLE
don't show multiple indexed attachments when cases are not shown as table

### DIFF
--- a/jgiven-html5-report/src/app/index.html
+++ b/jgiven-html5-report/src/app/index.html
@@ -93,14 +93,14 @@
   </span>
   <span bindonce ng-repeat="scenarioCase in scenario.scenarioCases"
         ng-init="step = scenarioCase.steps[$parent.$index]">
-          <span ng-if="step.attachment && !step.attachment.showDirectly">
+          <span ng-if="step.attachment && !step.attachment.showDirectly && (scenario.casesAsTable || scenarioCase.caseNr === case.caseNr )">
             <span aria-haspopup="{{ step.attachment.title ? 'true' : 'false'"
                   class="{{ step.attachment.title ? 'has-tip' : '' }}"
                   tooltip-html-unsafe="{{ step.attachment.title }}"
                   tooltip-popup-delay="250">
               <a target="_blank" href="data/{{ step.attachment.value }}">
                 <i class="fa fa-paperclip"><span class="attachment-index"
-                                                 ng-if="scenario.scenarioCases.length > 1">{{ scenarioCase.caseNr }}</span></i>
+                                                 ng-if="scenario.scenarioCases.length > 1 && scenario.casesAsTable">{{ scenarioCase.caseNr }}</span></i>
               </a>
             </span>
           </span>


### PR DESCRIPTION
I have a parameterized test case that is not shown as a table (due to different test steps depending on the parameters). 

What I see in HTML5 report of the current version (0.11.3): For every case all attachments of all cases are shown (= multiple paperclips on a single step).

What I want: Only the attachments of the current case should to be shown (without the index). 

This change fixes it for me. I'm not sure if this is the optimal code change as I'm not familiar with AngularJS - but it works for me. Please feel free to refactor.

I'm looking forward to a patch release if possible.