### PR TITLE
Allow adding tags dynamically.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Tags can now be hidden from the navigation bar in the HTML report by setting the `showInNavigation` attribute to `false` [#211](https://github.com/TNG/JGiven/issues/211).
 * Added a new CurrentScenario interface similar to CurrentStep.
 * The CurrentScenario interface allows adding tags programmatically, see [#172](https://github.com/TNG/JGiven/issues/172).
+* Allow tag annotations on step methods and step classes.
 
 ## Breaking Changes in the JSON model
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * Added a new comment() method to provide further information on specific step method invocations, see [#50](https://github.com/TNG/JGiven/issues/50).
 * Steps can now have multiple attachments [#194](https://github.com/TNG/JGiven/issues/194).
 * Tags can now be hidden from the navigation bar in the HTML report by setting the `showInNavigation` attribute to `false` [#211](https://github.com/TNG/JGiven/issues/211).
-* Added addTag() to ScenarioBase to allow adding tags dynamically, see [#172](https://github.com/TNG/JGiven/issues/172).
+* Added a new CurrentScenario interface similar to CurrentStep.
+* The CurrentScenario interface allows adding tags programmatically, see [#172](https://github.com/TNG/JGiven/issues/172).
 
 ## Breaking Changes in the JSON model
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added a new comment() method to provide further information on specific step method invocations, see [#50](https://github.com/TNG/JGiven/issues/50).
 * Steps can now have multiple attachments [#194](https://github.com/TNG/JGiven/issues/194).
 * Tags can now be hidden from the navigation bar in the HTML report by setting the `showInNavigation` attribute to `false` [#211](https://github.com/TNG/JGiven/issues/211).
+* Added addTag() to ScenarioBase to allow adding tags dynamically, see [#172](https://github.com/TNG/JGiven/issues/172).
 
 ## Breaking Changes in the JSON model
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/CurrentScenario.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/CurrentScenario.java
@@ -1,0 +1,23 @@
+package com.tngtech.jgiven;
+
+import java.lang.annotation.Annotation;
+
+import com.tngtech.jgiven.annotation.ScenarioState;
+
+/**
+ * This interface can be injected into a stage using the {@link ScenarioState} annotation.
+ * It provided programmatic access to the current scenario.
+ *
+ * @since 0.12.0
+ */
+public interface CurrentScenario {
+
+    /**
+     * Dynamically add a tag to the scenario.
+     * @param annotationClass The tag annotation class to use.
+     * @param values List of custom values.
+     * @since 0.12.0
+     */
+    void addTag( Class<? extends Annotation> annotationClass, String... values );
+
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/TagDescriptionGenerator.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/TagDescriptionGenerator.java
@@ -8,10 +8,10 @@ import com.tngtech.jgiven.config.TagConfiguration;
  * Is used as an attribute of the {@link com.tngtech.jgiven.annotation.IsTag} annotation
  * to dynamically generate a description for an annotation depending on its value.
  * <p>
- *     Implementations of this interface must be a public non-abstract class that is not a non-static inner class 
+ *     Implementations of this interface must be a public non-abstract class that is not a non-static inner class
  *     and must have a public default constructor.
  * </p>
- * 
+ *
  * @since 0.6.3
  */
 public interface TagDescriptionGenerator {
@@ -19,16 +19,17 @@ public interface TagDescriptionGenerator {
     /**
      * Implement this method to generate the description for the given annotation and its value.
      * <p>
-     *     Note that when the value of the annotation is an array and {@link com.tngtech.jgiven.annotation.IsTag#explodeArray()} 
+     *     Note that when the value of the annotation is an array and {@link com.tngtech.jgiven.annotation.IsTag#explodeArray()}
      *     is {@code true}, then this method is called for each value of the array and not once for the whole array.
      *     Otherwise it is called only once.
      * </p>
-     * @param tagConfiguration the configuration of the tag. The values typically correspond to the {@link IsTag annotation}. 
+     * @param tagConfiguration the configuration of the tag. The values typically correspond to the {@link IsTag annotation}.
      *                         However, it is also possible to configure annotations to be tags using {@link com.tngtech.jgiven.annotation.JGivenConfiguration},
      *                         in which case there is no {@link IsTag} annotation.
-     * @param annotation the actual annotation that was used as a tag
+     * @param annotation the actual annotation that was used as a tag. Note that this can be {@code null} in the case of
+     *                   dynamically added tags.
      * @param value the value of the annotation. If the annotation has no value the default value is passed ({@link com.tngtech.jgiven.annotation.IsTag#value()}
-     *              
+     *
      * @return the description of the annotation for the given value
      */
     String generateDescription( TagConfiguration tagConfiguration, Annotation annotation, Object value );

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/TagHrefGenerator.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/TagHrefGenerator.java
@@ -26,9 +26,10 @@ public interface TagHrefGenerator {
      * @param tagConfiguration the configuration of the tag. The values typically correspond to the {@link IsTag annotation}.
      *                         However, it is also possible to configure annotations to be tags using {@link JGivenConfiguration},
      *                         in which case there is no {@link IsTag} annotation.
-     * @param annotation the actual annotation that was used as a tag
+     * @param annotation the actual annotation that was used as a tag. Note that this can be {@code null} in the case of
+     *                   dynamically added tags.
      * @param value the value of the annotation. If the annotation has no value the default value is passed ({@link IsTag#value()}
-     *              
+     *
      * @return the description of the annotation for the given value
      */
     String generateHref( TagConfiguration tagConfiguration, Annotation annotation, Object value );

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioBase.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioBase.java
@@ -1,5 +1,6 @@
 package com.tngtech.jgiven.impl;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 
@@ -112,6 +113,16 @@ public class ScenarioBase {
      */
     public void section( String sectionTitle ) {
         executor.addSection( sectionTitle );
+    }
+
+    /**
+     * Dynamically add a tag to the scenario.
+     * @param annotationClass The tag annotation class to use.
+     * @param values List of custom values. This must be supported by the given tag.
+     * @since 0.12.0
+     */
+    public void addTag( Class<? extends Annotation> annotationClass, String... values ) {
+        executor.addTag( annotationClass, values );
     }
 
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioBase.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioBase.java
@@ -1,6 +1,5 @@
 package com.tngtech.jgiven.impl;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 
@@ -113,16 +112,6 @@ public class ScenarioBase {
      */
     public void section( String sectionTitle ) {
         executor.addSection( sectionTitle );
-    }
-
-    /**
-     * Dynamically add a tag to the scenario.
-     * @param annotationClass The tag annotation class to use.
-     * @param values List of custom values. This must be supported by the given tag.
-     * @since 0.12.0
-     */
-    public void addTag( Class<? extends Annotation> annotationClass, String... values ) {
-        executor.addTag( annotationClass, values );
     }
 
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioExecutor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioExecutor.java
@@ -1,5 +1,6 @@
 package com.tngtech.jgiven.impl;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 
@@ -24,6 +25,8 @@ public interface ScenarioExecutor {
     void addIntroWord( String word );
 
     void addSection( String sectionTitle );
+
+    void addTag( Class<? extends Annotation> annotationClass, String... values );
 
     void readScenarioState( Object object );
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioExecutor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioExecutor.java
@@ -26,8 +26,6 @@ public interface ScenarioExecutor {
 
     void addSection( String sectionTitle );
 
-    void addTag( Class<? extends Annotation> annotationClass, String... values );
-
     void readScenarioState( Object object );
 
     /**

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
@@ -174,6 +174,9 @@ public class ScenarioModelBuilder implements ScenarioListener {
         } else if( method.isAnnotationPresent( StepComment.class ) ) {
             stepCommentAdded( arguments );
         } else {
+            addTags( method.getAnnotations() );
+            addTags( method.getDeclaringClass().getAnnotations() );
+
             addStepMethod( method, arguments, mode, hasNestedSteps );
         }
     }
@@ -388,8 +391,17 @@ public class ScenarioModelBuilder implements ScenarioListener {
     }
 
     private void addTags( List<Tag> tags ) {
-        this.reportModel.addTags( tags );
-        this.scenarioModel.addTags( tags );
+        if( tags.isEmpty() ) {
+            return;
+        }
+
+        if( reportModel != null ) {
+            this.reportModel.addTags( tags );
+        }
+
+        if( scenarioModel != null ) {
+            this.scenarioModel.addTags( tags );
+        }
     }
 
     public List<Tag> toTags( Annotation annotation ) {

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.tngtech.jgiven.CurrentScenario;
 import com.tngtech.jgiven.CurrentStep;
 import com.tngtech.jgiven.annotation.AfterScenario;
 import com.tngtech.jgiven.annotation.AfterStage;
@@ -80,6 +81,7 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
     public StandaloneScenarioExecutor() {
         injector.injectValueByType( StandaloneScenarioExecutor.class, this );
         injector.injectValueByType( CurrentStep.class, new StepAccessImpl() );
+        injector.injectValueByType( CurrentScenario.class, new ScenarioAccessImpl() );
     }
 
     protected static class StageState {
@@ -104,6 +106,15 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
         public void setExtendedDescription( String extendedDescription ) {
             listener.extendedDescriptionUpdated( extendedDescription );
         }
+    }
+
+    class ScenarioAccessImpl implements CurrentScenario {
+
+        @Override
+        public void addTag( Class<? extends Annotation> annotationClass, String... values ) {
+            listener.tagAdded( annotationClass, values );
+        }
+
     }
 
     class MethodHandler implements StepMethodHandler {
@@ -531,11 +542,6 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
     @Override
     public void addSection( String sectionTitle ) {
         listener.sectionAdded( sectionTitle );
-    }
-
-    @Override
-    public void addTag( Class<? extends Annotation> annotationClass, String... values ) {
-        listener.tagAdded( annotationClass, values );
     }
 
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/StandaloneScenarioExecutor.java
@@ -533,4 +533,9 @@ public class StandaloneScenarioExecutor implements ScenarioExecutor {
         listener.sectionAdded( sectionTitle );
     }
 
+    @Override
+    public void addTag( Class<? extends Annotation> annotationClass, String... values ) {
+        listener.tagAdded( annotationClass, values );
+    }
+
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/NoOpScenarioListener.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/NoOpScenarioListener.java
@@ -1,5 +1,6 @@
 package com.tngtech.jgiven.impl.intercept;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 
@@ -43,7 +44,8 @@ public class NoOpScenarioListener implements ScenarioListener {
     public void extendedDescriptionUpdated( String extendedDescription ) {}
 
     @Override
-    public void sectionAdded( String sectionTitle ) {
+    public void sectionAdded( String sectionTitle ) {}
 
-    }
+    @Override
+    public void tagAdded( Class<? extends Annotation> annotationClass, String... values ) {}
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/ScenarioListener.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/ScenarioListener.java
@@ -1,5 +1,6 @@
 package com.tngtech.jgiven.impl.intercept;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 
@@ -32,4 +33,6 @@ public interface ScenarioListener {
     void extendedDescriptionUpdated( String extendedDescription );
 
     void sectionAdded( String sectionTitle );
+
+    void tagAdded( Class<? extends Annotation> annotationClass, String... values );
 }

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/tags/DynamicTags.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/tags/DynamicTags.java
@@ -1,9 +1,14 @@
 package com.tngtech.jgiven.examples.tags;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 import org.junit.Test;
 
+import com.tngtech.jgiven.CurrentScenario;
+import com.tngtech.jgiven.annotation.IsTag;
+import com.tngtech.jgiven.annotation.ScenarioState;
 import com.tngtech.jgiven.junit.SimpleScenarioTest;
-import com.tngtech.jgiven.tags.Issue;
 
 /**
  * This example shows how tags can be added dynamically at runtime.
@@ -12,9 +17,46 @@ public class DynamicTags extends SimpleScenarioTest<DynamicTags.Steps> {
 
     @Test
     public void tags_can_be_added_dynamically() {
-        getScenario().addTag( Issue.class, "Value" );
+        given().an_order_for_a_$_car( CarType.BMW );
+        when().the_order_is_processed();
+        then().the_car_is_sent_to_manufacturing();
     }
 
-    public static class Steps {}
+    public static class Steps {
+        @ScenarioState
+        CurrentScenario currentScenario;
+
+        Steps an_order_for_a_$_car( CarType type ) {
+            /*
+             * Dynamically add a tag with a value depending on the passed
+             * argument.
+             */
+            currentScenario.addTag( CarOrder.class, type.name );
+            return this;
+        }
+
+        Steps the_order_is_processed() {
+            return this;
+        }
+
+        Steps the_car_is_sent_to_manufacturing() {
+            return this;
+        }
+    }
+
+    @IsTag
+    @Retention( RetentionPolicy.RUNTIME )
+    @interface CarOrder {}
+
+    private static enum CarType {
+        AUDI( "Audi" ),
+        BMW( "BMW" );
+
+        final String name;
+
+        private CarType( String name ) {
+            this.name = name;
+        }
+    }
 
 }

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/tags/DynamicTags.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/tags/DynamicTags.java
@@ -1,0 +1,20 @@
+package com.tngtech.jgiven.examples.tags;
+
+import org.junit.Test;
+
+import com.tngtech.jgiven.junit.SimpleScenarioTest;
+import com.tngtech.jgiven.tags.Issue;
+
+/**
+ * This example shows how tags can be added dynamically at runtime.
+ */
+public class DynamicTags extends SimpleScenarioTest<DynamicTags.Steps> {
+
+    @Test
+    public void tags_can_be_added_dynamically() {
+        getScenario().addTag( Issue.class, "Value" );
+    }
+
+    public static class Steps {}
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/tags/StepTags.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/tags/StepTags.java
@@ -1,0 +1,75 @@
+package com.tngtech.jgiven.examples.tags;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.Test;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.IsTag;
+import com.tngtech.jgiven.junit.SimpleScenarioTest;
+
+/**
+ * This example demonstrates that tag annotations can also be provided
+ * by stage methods and stage classes.
+ *
+ * Providing tags through steps rather than tests has the benefit that
+ * all new tests using these steps will automatically be tagged accordingly.
+ * Furthermore, it allows tagging many tests by only tagging an individual
+ * step method or class.
+ */
+public class StepTags extends SimpleScenarioTest<StepTags.Steps> {
+
+    @Test
+    public void premium_members_can_order_premium_products() {
+        given().a_premium_customer()
+            .and().a_product()
+            .and().the_product_is_only_available_for_premium_members();
+        when().the_customer_orders_the_product();
+        then().the_product_is_shipped();
+    }
+
+    @Shop
+    public static class Steps extends Stage<Steps> {
+        @PremiumMembership
+        Steps a_premium_customer() {
+            return this;
+        }
+
+        Steps a_product() {
+            return this;
+        }
+
+        @PremiumProduct
+        Steps the_product_is_only_available_for_premium_members() {
+            return this;
+        }
+
+        Steps the_customer_orders_the_product() {
+            return this;
+        }
+
+        Steps the_product_is_shipped() {
+            return this;
+        }
+    }
+
+    @IsTag
+    @Retention( RetentionPolicy.RUNTIME )
+    @interface Shop {}
+
+    @IsTag
+    @Retention( RetentionPolicy.RUNTIME )
+    @interface Premium {}
+
+    @IsTag
+    @Retention( RetentionPolicy.RUNTIME )
+    @Premium
+    @interface PremiumMembership {}
+
+    @IsTag
+    @Retention( RetentionPolicy.RUNTIME )
+    @Premium
+    @interface PremiumProduct {}
+
+}

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/ScenarioExecutionTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/ScenarioExecutionTest.java
@@ -1,6 +1,17 @@
 package com.tngtech.jgiven.junit;
 
+import static com.tngtech.jgiven.annotation.ScenarioState.Resolution.NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.jgiven.CurrentScenario;
 import com.tngtech.jgiven.CurrentStep;
 import com.tngtech.jgiven.Stage;
 import com.tngtech.jgiven.annotation.*;
@@ -12,13 +23,6 @@ import com.tngtech.jgiven.junit.test.BeforeAfterTestStage;
 import com.tngtech.jgiven.junit.test.ThenTestStep;
 import com.tngtech.jgiven.junit.test.WhenTestStep;
 import com.tngtech.jgiven.report.model.AttachmentModel;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import java.util.List;
-
-import static com.tngtech.jgiven.annotation.ScenarioState.Resolution.NAME;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith( DataProviderRunner.class )
 @JGivenConfiguration( TestConfiguration.class )
@@ -73,8 +77,7 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
         stage.something();
     }
 
-    static class SomeType {
-    }
+    static class SomeType {}
 
     public static class TestStageWithAmbiguousFields {
         @ScenarioState
@@ -83,8 +86,7 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
         @ScenarioState
         SomeType secondType;
 
-        public void something() {
-        }
+        public void something() {}
     }
 
     @Test
@@ -101,8 +103,7 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
         @ScenarioState( resolution = NAME )
         SomeType secondType;
 
-        public void something() {
-        }
+        public void something() {}
     }
 
     @Test( expected = IllegalStateException.class )
@@ -168,8 +169,7 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
     }
 
     @SuppressWarnings( "serial" )
-    static class SomeExceptionInAfterStage extends RuntimeException {
-    }
+    static class SomeExceptionInAfterStage extends RuntimeException {}
 
     static class AssertionInAfterStage extends Stage<AssertionInAfterStage> {
         @AfterStage
@@ -177,8 +177,7 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
             throw new SomeExceptionInAfterStage();
         }
 
-        public void something() {
-        }
+        public void something() {}
     }
 
     @Test( expected = SomeExceptionInAfterStage.class )
@@ -233,8 +232,7 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
         @ProvidedScenarioState
         String someString = "test";
 
-        public void something() {
-        }
+        public void something() {}
     }
 
     static class SomeStageWithAHiddenMethod {
@@ -254,7 +252,6 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
 
         stage1.something();
         stage2.someHiddenStep();
-
     }
 
     static class SomeStageWithABeforeMethod {
@@ -266,8 +263,7 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
             assertThat( someString ).isNotNull();
         }
 
-        public void something() {
-        }
+        public void something() {}
     }
 
     @Test
@@ -277,7 +273,6 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
 
         stage1.something();
         stage2.something();
-
     }
 
     static class AttachmentStepClass {
@@ -317,14 +312,37 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
         assertThat( description ).isEqualTo( "An extended description" );
     }
 
+    @IsTag
+    @Retention( RetentionPolicy.RUNTIME )
+    @interface DynamicTag {}
+
+    static class CurrentScenarioStage {
+        @ScenarioState
+        CurrentScenario currentScenario;
+
+        public void add_tag() {
+            currentScenario.addTag( DynamicTag.class, "value" );
+        }
+    }
+
+    @Test
+    public void tags_can_be_added_using_the_current_scenario() {
+        CurrentScenarioStage steps = addStage( CurrentScenarioStage.class );
+
+        steps.add_tag();
+
+        List<String> tagIds = getScenario().getScenarioModel().getTagIds();
+        assertThat( tagIds ).hasSize( 1 );
+        assertThat( tagIds.get( 0 ) ).isEqualTo( "DynamicTag-value" );
+    }
+
     static abstract class AbstractStage {
         public abstract void abstract_step();
     }
 
     static class ConcreteStage extends AbstractStage {
         @Override
-        public void abstract_step() {
-        }
+        public void abstract_step() {}
     }
 
     @Test

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/TagAnnotationTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/TagAnnotationTest.java
@@ -1,22 +1,23 @@
 package com.tngtech.jgiven.junit;
 
-import com.tngtech.jgiven.annotation.IsTag;
-import com.tngtech.jgiven.junit.test.GivenTestStep;
-import com.tngtech.jgiven.junit.test.ThenTestStep;
-import com.tngtech.jgiven.junit.test.WhenTestStep;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+
+import com.tngtech.jgiven.annotation.IsTag;
+import com.tngtech.jgiven.junit.test.GivenTaggedTestStep;
+import com.tngtech.jgiven.junit.test.GivenTestStep;
+import com.tngtech.jgiven.junit.test.ThenTestStep;
+import com.tngtech.jgiven.junit.test.WhenTestStep;
 
 public class TagAnnotationTest extends ScenarioTest<GivenTestStep, WhenTestStep, ThenTestStep> {
 
     @IsTag( showInNavigation = false )
     @Retention( RetentionPolicy.RUNTIME )
     @interface TagNotShownInNavigation {}
-
 
     @TagNotShownInNavigation
     @Test
@@ -26,6 +27,25 @@ public class TagAnnotationTest extends ScenarioTest<GivenTestStep, WhenTestStep,
         getScenario().finished();
 
         assertThat( getScenario().getModel().getTagMap().entrySet().iterator().next().getValue().getShownInNavigation() )
-                .isEqualTo( false );
+            .isEqualTo( false );
+    }
+
+    @Test
+    public void tag_on_step_method_is_recognized() throws Throwable {
+        given().a_tagged_step_method();
+
+        getScenario().finished();
+
+        assertThat( getScenario().getModel().getTagMap().keySet() ).contains( "StepMethodTag" );
+    }
+
+    @Test
+    public void tag_on_stage_class_is_recognized() throws Throwable {
+        GivenTaggedTestStep givenTaggedTestStep = addStage( GivenTaggedTestStep.class );
+        givenTaggedTestStep.some_step_method_in_a_tagged_stage();
+
+        getScenario().finished();
+
+        assertThat( getScenario().getModel().getTagMap().keySet() ).contains( "StageTag" );
     }
 }

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/GivenTaggedTestStep.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/GivenTaggedTestStep.java
@@ -1,0 +1,18 @@
+package com.tngtech.jgiven.junit.test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.tngtech.jgiven.annotation.IsTag;
+import com.tngtech.jgiven.junit.test.GivenTaggedTestStep.StageTag;
+
+@StageTag
+public class GivenTaggedTestStep extends GivenTestStep {
+
+    @IsTag
+    @Retention( RetentionPolicy.RUNTIME )
+    @interface StageTag {}
+
+    public void some_step_method_in_a_tagged_stage() {}
+
+}

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/GivenTestStep.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/GivenTestStep.java
@@ -3,11 +3,14 @@ package com.tngtech.jgiven.junit.test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.List;
 
 import com.google.common.collect.Lists;
 import com.tngtech.jgiven.Stage;
 import com.tngtech.jgiven.annotation.Format;
+import com.tngtech.jgiven.annotation.IsTag;
 import com.tngtech.jgiven.annotation.ProvidedScenarioState;
 import com.tngtech.jgiven.annotation.Quoted;
 import com.tngtech.jgiven.annotation.Table;
@@ -34,6 +37,13 @@ public class GivenTestStep extends Stage<GivenTestStep> {
     public void some_boolean_value( boolean someBooleanValue ) {
 
     }
+
+    @IsTag
+    @Retention( RetentionPolicy.RUNTIME )
+    @interface StepMethodTag {}
+
+    @StepMethodTag
+    public void a_tagged_step_method() {}
 
     public void $d_and_$d( int value1, int value2 ) {
         this.value1 = value1;


### PR DESCRIPTION
This commit allows adding tags dynamically to a scenario at runtime.
Furthermore, it implicitly fixes an issue where nested tags, description
and href would not be evaluated if ignoreValue was set to true.

fixes #172