### PR TITLE
allow `gradlew publishToMavenLocal`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,18 @@ subprojects {
     apply plugin: 'signing'
     apply plugin: 'org.asciidoctor.convert'
     apply plugin: 'ru.vyarus.animalsniffer'
+    apply plugin: 'maven-publish'
 
     description "${rootProject.description} - Module ${project.name}"
     sourceCompatibility = targetCompatibility = 1.6
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+            }
+        }
+    }
 
     ext {
         junitDataproviderVersion = '1.11.0'

--- a/jgiven-maven-plugin/build.gradle
+++ b/jgiven-maven-plugin/build.gradle
@@ -23,7 +23,7 @@ generateMavenPlugin.onlyIf {
    // as the generateMavenPlugin task requires mvn, it is only executed
    // when actually uploading the archives
    // that way the standard build stays maven-free
-   gradle.taskGraph.hasTask(uploadArchives)
+   gradle.taskGraph.hasTask(uploadArchives) || gradle.taskGraph.hasTask(publishToMavenLocal)
 }
 
 task copyMavenPlugin(type: Copy, dependsOn: generateMavenPlugin) {


### PR DESCRIPTION
As a contributor I want to use `gradlew publishToMavenLocal` so I can test my contributions easily together with my local projects.

Therefore I added _maven-publish_. As I'm unexperienced with gradle, I might have missed something. But it now works for me.

Please advise if changes are necessary.