### PR TITLE
use full class name as ID of a tag

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/config/TagConfiguration.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/config/TagConfiguration.java
@@ -16,6 +16,7 @@ import java.util.List;
  */
 public class TagConfiguration {
     private final String annotationType;
+    private final String annotationFullType;
     private boolean ignoreValue;
     private boolean explodeArray = true;
     private boolean prependType;
@@ -33,6 +34,7 @@ public class TagConfiguration {
 
     public TagConfiguration( Class<? extends Annotation> tagAnnotation ) {
         this.annotationType = tagAnnotation.getSimpleName();
+        this.annotationFullType = tagAnnotation.getName();
     }
 
     public static Builder builder( Class<? extends Annotation> tagAnnotation ) {
@@ -216,6 +218,10 @@ public class TagConfiguration {
 
     public String getAnnotationType() {
         return annotationType;
+    }
+
+    public String getAnnotationFullType() {
+        return annotationFullType;
     }
 
     /**

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
@@ -439,7 +439,9 @@ public class ScenarioModelBuilder implements ScenarioListener {
     }
 
     private List<Tag> toTags( TagConfiguration tagConfig, Optional<Annotation> annotation ) {
-        Tag tag = new Tag( tagConfig.getAnnotationType() );
+        Tag tag = new Tag( tagConfig.getAnnotationFullType() );
+
+        tag.setType( tagConfig.getAnnotationType() );
 
         if( !Strings.isNullOrEmpty( tagConfig.getName() ) ) {
             tag.setName( tagConfig.getName() );

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/Tag.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/Tag.java
@@ -12,9 +12,14 @@ import java.util.List;
  */
 public class Tag {
     /**
-     * The type of the annotation of the tag
+     * The full type of the annotation of the tag
      */
-    private final String type;
+    private final String fullType;
+
+    /**
+     * The simple type of the annotation of the tag
+     */
+    private String type;
 
     /**
      * An optional name of the tag. If not set, the type is the name
@@ -75,17 +80,17 @@ public class Tag {
      */
     private Boolean hideInNav;
 
-    public Tag( String type ) {
-        this.type = type;
+    public Tag( String fullType ) {
+        this.fullType = fullType;
     }
 
-    public Tag( String type, Object value ) {
-        this( type );
+    public Tag( String fullType, Object value ) {
+        this( fullType );
         this.value = value;
     }
 
-    public Tag( String type, String name, Object value ) {
-        this( type, value );
+    public Tag( String fullType, String name, Object value ) {
+        this( fullType, value );
         this.name = name;
     }
 
@@ -135,6 +140,14 @@ public class Tag {
 
     public String getStyle() {
         return style;
+    }
+
+    public void setType( String type ) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
     }
 
     public String getHref() {
@@ -194,14 +207,14 @@ public class Tag {
 
     public String toIdString() {
         if( value != null ) {
-            return type + "-" + getValueString();
+            return fullType + "-" + getValueString();
         }
-        return type;
+        return fullType;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode( getType(), getName(), value );
+        return Objects.hashCode( getFullType(), getName(), value );
     }
 
     @Override
@@ -216,7 +229,7 @@ public class Tag {
             return false;
         }
         Tag other = (Tag) obj;
-        return Objects.equal( getType(), other.getType() )
+        return Objects.equal( getFullType(), other.getFullType() )
                 && Objects.equal( getName(), other.getName() )
                 && Objects.equal( value, other.value );
     }
@@ -242,8 +255,8 @@ public class Tag {
         this.name = name;
     }
 
-    public String getType() {
-        return type;
+    public String getFullType() {
+        return fullType;
     }
 
     public boolean getShownInNavigation() {
@@ -264,7 +277,8 @@ public class Tag {
     }
 
     public Tag copy() {
-        Tag tag = new Tag( type, name, value );
+        Tag tag = new Tag( fullType, name, value );
+        tag.type = this.type;
         tag.cssClass = this.cssClass;
         tag.color = this.color;
         tag.style = this.style;

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ScenarioModelBuilderTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ScenarioModelBuilderTest.java
@@ -94,7 +94,7 @@ public class ScenarioModelBuilderTest extends ScenarioTestBaseForTesting<GivenTe
         Tag tag = tags.get( 0 );
         assertThat( tag.getName() ).isEqualTo( "AnotherName" );
         assertThat( tag.getValues() ).isEmpty();
-        assertThat( tag.toIdString() ).isEqualTo( "AnnotationWithName" );
+        assertThat( tag.toIdString() ).isEqualTo( this.getClass().getName() + "$AnnotationWithName" );
     }
 
     @IsTag( ignoreValue = true )
@@ -113,7 +113,7 @@ public class ScenarioModelBuilderTest extends ScenarioTestBaseForTesting<GivenTe
         Tag tag = tags.get( 0 );
         assertThat( tag.getName() ).isEqualTo( "AnnotationWithIgnoredValue" );
         assertThat( tag.getValues() ).isEmpty();
-        assertThat( tag.toIdString() ).isEqualTo( "AnnotationWithIgnoredValue" );
+        assertThat( tag.toIdString() ).isEqualTo( this.getClass().getName() + "$AnnotationWithIgnoredValue" );
     }
 
     @IsTag
@@ -209,7 +209,7 @@ public class ScenarioModelBuilderTest extends ScenarioTestBaseForTesting<GivenTe
         List<Tag> tags = getScenarioModelBuilder().toTags( AnnotationWithParentTag.class.getAnnotations()[0] );
         assertThat( tags ).hasSize( 1 );
         assertThat( tags.get( 0 ).getTags() ).containsAll( Arrays.asList(
-            "ParentTag", "ParentTagWithValue-SomeValue" ) );
+                this.getClass().getName() + "$ParentTag", this.getClass().getName() + "$ParentTagWithValue-SomeValue" ) );
     }
 
     @IsTag( value = "default" )

--- a/jgiven-html5-report/src/app/lib/reportCtrl.js
+++ b/jgiven-html5-report/src/app/lib/reportCtrl.js
@@ -86,6 +86,12 @@ jgivenReportApp.controller('JGivenReportCtrl', function ($scope, $rootScope, $do
         var tagNameNode = tagService.getTagNameNode(part[2]);
         $scope.updateCurrentPageToTagNameNode(tagNameNode, selectedOptions);
       }
+    } else if (part[1] === 'tagid') {
+      var tag = tagService.getTagByKey(getTagKey({
+          fullType: part[2],
+          value: part[3]
+      }));
+      $scope.updateCurrentPageToTag(tag, selectedOptions);
     } else if (part[1] === 'class') {
       $scope.updateCurrentPageToClassName(part[2], selectedOptions);
     } else if (part[1] === 'package') {
@@ -540,7 +546,7 @@ jgivenReportApp.controller('JGivenReportCtrl', function ($scope, $rootScope, $do
     if (tag.href) {
       return tag.href;
     }
-    return '#tag/' + getTagName(tag) +
+    return '#tagid/' + getTagId(tag) +
       (tag.value ? '/' + $window.encodeURIComponent(tag.value) : '');
   };
 

--- a/jgiven-html5-report/src/app/lib/tagService.js
+++ b/jgiven-html5-report/src/app/lib/tagService.js
@@ -143,7 +143,7 @@ jgivenReportApp.factory('tagService', ['dataService', function (dataService) {
       var node = createNode(tagToString(tag));
 
       node.url = function () {
-        return '#tag/' + window.encodeURIComponent(getTagName(tag)) +
+        return '#tagid/' + window.encodeURIComponent(getTagId(tag)) +
           (tag.value ? '/' + window.encodeURIComponent(tag.value) : '');
       };
 

--- a/jgiven-html5-report/src/app/lib/util.js
+++ b/jgiven-html5-report/src/app/lib/util.js
@@ -64,8 +64,12 @@ function getTagName (tag) {
   return tag.name ? tag.name : tag.type;
 }
 
+function getTagId (tag) {
+  return tag.fullType ? tag.fullType : tag.type;
+}
+
 function getTagKey (tag) {
-  return getTagName(tag) + (tag.value ? '-' + tag.value : '');
+  return getTagId(tag) + (tag.value ? '-' + tag.value : '');
 }
 
 function tagToString (tag) {

--- a/jgiven-html5-report/src/main/java/com/tngtech/jgiven/report/html5/TagFile.java
+++ b/jgiven-html5-report/src/main/java/com/tngtech/jgiven/report/html5/TagFile.java
@@ -24,23 +24,23 @@ public class TagFile {
             Tag tag = entry.getValue().copy();
             tag.setValue( (String) null );
 
-            if( !tagTypeMap.containsKey( tag.getType() ) ) {
-                tagTypeMap.put( tag.getType(), tag );
+            if( !tagTypeMap.containsKey( tag.getFullType() ) ) {
+                tagTypeMap.put( tag.getFullType(), tag );
             }
 
             TagInstance instance = new TagInstance();
-            instance.tagType = tag.getType();
+            instance.tagType = tag.getFullType();
             instance.value = entry.getValue().getValueString();
 
             // the description might be generated depending on the value, so it must be stored
             // for each tag instance separately
-            if( !ObjectUtil.equals( entry.getValue().getDescription(), tagTypeMap.get( tag.getType() ).getDescription() ) ) {
+            if( !ObjectUtil.equals( entry.getValue().getDescription(), tagTypeMap.get( tag.getFullType() ).getDescription() ) ) {
                 instance.description = entry.getValue().getDescription();
             }
 
             // the href might be generated depending on the value, so it must be stored
             // for each tag instance separately
-            if( !ObjectUtil.equals( entry.getValue().getHref(), tagTypeMap.get( tag.getType() ).getHref() ) ) {
+            if( !ObjectUtil.equals( entry.getValue().getHref(), tagTypeMap.get( tag.getFullType() ).getHref() ) ) {
                 instance.href = entry.getValue().getHref();
             }
             tags.put( entry.getKey(), instance );

--- a/jgiven-html5-report/src/test/app/tagServiceTest.js
+++ b/jgiven-html5-report/src/test/app/tagServiceTest.js
@@ -131,7 +131,7 @@ describe("TagService", function () {
     var scenarios = tagService.getScenariosByTag(tagService.getTagByKey('issue-1'));
     expect(scenarios.length).toEqual(1);
     expect(scenarios[0].tags.length).toEqual(testCases[0].scenarios[0].tagIds.length);
-    expect(_.map(scenarios[0].tags, getTagKey)).toEqual(['issue-1', 'issue-2', 'categoryB', 'feature-A', 'feature-B', 'something-someA']);
+    expect(_.map(scenarios[0].tags, getTagKey)).toEqual(['issue-1', 'issue-2', 'categoryB', 'featureA-A', 'featureB-B', 'somethingA-someA']);
   });
 
 });

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/ScenarioExecutionTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/ScenarioExecutionTest.java
@@ -216,7 +216,7 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
         assertThat( tagIds ).isNotEmpty();
         String tagId = tagIds.get( 0 );
         assertThat( tagId ).isNotNull();
-        assertThat( tagId ).isEqualTo( "ConfiguredTag-Test" );
+        assertThat( tagId ).isEqualTo( ConfiguredTag.class.getName() + "-Test" );
     }
 
     @Test
@@ -333,7 +333,7 @@ public class ScenarioExecutionTest extends ScenarioTest<BeforeAfterTestStage, Wh
 
         List<String> tagIds = getScenario().getScenarioModel().getTagIds();
         assertThat( tagIds ).hasSize( 1 );
-        assertThat( tagIds.get( 0 ) ).isEqualTo( "DynamicTag-value" );
+        assertThat( tagIds.get( 0 ) ).isEqualTo( this.getClass().getName() + "$DynamicTag-value" );
     }
 
     static abstract class AbstractStage {

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/StepsAreReportedTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/StepsAreReportedTest.java
@@ -113,7 +113,7 @@ public class StepsAreReportedTest extends ScenarioTest<TestSteps, TestSteps, Tes
         assertThat( model.getTagIds() ).hasSize( 1 );
 
         String tagId = model.getTagIds().get( 0 );
-        assertThat( tagId ).isEqualTo( "TestTag-foo, bar, baz" );
+        assertThat( tagId ).isEqualTo( this.getClass().getName() + "$TestTag-foo, bar, baz" );
 
         Tag tag = reportModel.getTagWithId( tagId );
         assertThat( tag ).isNotNull();

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/TagAnnotationTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/TagAnnotationTest.java
@@ -36,7 +36,7 @@ public class TagAnnotationTest extends ScenarioTest<GivenTestStep, WhenTestStep,
 
         getScenario().finished();
 
-        assertThat( getScenario().getModel().getTagMap().keySet() ).contains( "StepMethodTag" );
+        assertThat( getScenario().getModel().getTagMap().keySet() ).contains( "com.tngtech.jgiven.junit.test.GivenTestStep$StepMethodTag" );
     }
 
     @Test
@@ -46,6 +46,6 @@ public class TagAnnotationTest extends ScenarioTest<GivenTestStep, WhenTestStep,
 
         getScenario().finished();
 
-        assertThat( getScenario().getModel().getTagMap().keySet() ).contains( "StageTag" );
+        assertThat( getScenario().getModel().getTagMap().keySet() ).contains( "com.tngtech.jgiven.junit.test.GivenTaggedTestStep$StageTag" );
     }
 }

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/tags/AbstractScenarioForTestingTagInheritance.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/tags/AbstractScenarioForTestingTagInheritance.java
@@ -16,7 +16,7 @@ public abstract class AbstractScenarioForTestingTagInheritance<G, W, T> extends 
         getScenario().finished();
 
         List<String> tagIds = getScenario().getModel().getLastScenarioModel().getTagIds();
-        assertThat( tagIds ).containsAll( Arrays.asList( "TestTag" ) );
+        assertThat( tagIds ).containsAll( Arrays.asList( TestTag.class.getName() ) );
 
     }
 }

--- a/jgiven-tests/src/test/java/com/tngtech/jgiven/report/model/GivenReportModel.java
+++ b/jgiven-tests/src/test/java/com/tngtech/jgiven/report/model/GivenReportModel.java
@@ -221,6 +221,7 @@ public class GivenReportModel<SELF extends GivenReportModel<?>> extends Stage<SE
 
     public SELF scenario_$_has_tag_$_with_value_$( int i, String name, String value ) {
         latestTag = new Tag( name, value ).setPrependType( true );
+        latestTag.setType( name );
         reportModel.getScenarios().get( i - 1 ).addTag( latestTag );
         reportModel.addTag( latestTag );
         return self();

--- a/jgiven-tests/src/test/java/com/tngtech/jgiven/testframework/TestFrameworkExecutionTest.java
+++ b/jgiven-tests/src/test/java/com/tngtech/jgiven/testframework/TestFrameworkExecutionTest.java
@@ -140,7 +140,7 @@ public class TestFrameworkExecutionTest extends JGivenScenarioTest<GivenScenario
         given().a_test()
             .and().the_test_has_a_tag_annotation_named( "TestTag" );
         when().the_test_is_executed_with( testFramework );
-        then().the_report_model_contains_a_tag_named( "TestTag" );
+        then().the_report_model_contains_a_tag_named( "com.tngtech.jgiven.tests.TestTag" );
     }
 
     @Test


### PR DESCRIPTION
In our project we use very many tags, and we order them in hierarchies and with inner classes. Sometimes inner classes have the same names (as they are the leaves of our tree).  This is currently not supported by JGiven, as it uses the class' simpleName to index the tags. I know that this is to some extent documented in @IsTag#name - but it seems to be a bit outdated as it talks about "type name".

This tries to introduce the full class name to derive the IDs of the tags, while preserving the existing functionality to use the simple name as the default name of the tag. The ID will only be used for the internal indexing, and will not be shown to the user.

I've tested this with the HTML5 report and it works for me AFAICS. Let me know what you think - I wonder if it breaks functionality or (too much) backwards compatibility.

In addition to this the _...#/tag/name_ navigation used in the HTML5 report should use something like _...#/tagid/id_ to uniquely identify tags not by their name, but by their ID. I'll look into this once we agree on the Java code.
