### PR TITLE
Add initial version of JGiven Gradle plugin

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/Config.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/Config.java
@@ -1,12 +1,11 @@
 package com.tngtech.jgiven.impl;
 
-import java.io.File;
-
+import com.google.common.base.Optional;
 import com.tngtech.jgiven.config.ConfigValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
+import java.io.File;
 
 /**
  * Helper class to access all system properties to configure JGiven.
@@ -19,7 +18,7 @@ public class Config {
     private static final String FALSE = "false";
     private static final String AUTO = "auto";
     private static final String JGIVEN_REPORT_ENABLED = "jgiven.report.enabled";
-    private static final String JGIVEN_REPORT_DIR = "jgiven.report.dir";
+    public static final String JGIVEN_REPORT_DIR = "jgiven.report.dir";
     private static final String JGIVEN_REPORT_TEXT = "jgiven.report.text";
     private static final String JGIVEN_REPORT_TEXT_COLOR = "jgiven.report.text.color";
     private static final String JGIVEN_FILTER_STACK_TRACE = "jgiven.report.filterStackTrace";

--- a/jgiven-gradle-plugin/build.gradle
+++ b/jgiven-gradle-plugin/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id "java-gradle-plugin"
+    id "com.gradle.plugin-publish" version "0.9.6"
+}
+
+sourceCompatibility = targetCompatibility = 1.7
+
+dependencies {
+    compile project(':jgiven-core')
+    compile project(':jgiven-html5-report')
+
+    testCompile gradleTestKit()
+    testCompile project(':jgiven-junit')
+}
+
+gradlePlugin {
+    plugins {
+        jgivenPlugin {
+            id = "com.tngtech.jgiven.gradle-plugin"
+            implementationClass = "com.tngtech.jgiven.gradle.JGivenPlugin"
+        }
+    }
+}
+
+pluginBundle {
+    website = 'http://jgiven.org/'
+    vcsUrl = 'https://github.com/TNG/JGiven.git'
+    description = 'JGiven Gradle plugin'
+    tags = ['jgiven', 'testing']
+
+    plugins {
+        jgivenPlugin {
+            id = gradlePlugin.plugins.jgivenPlugin.id
+            displayName = 'Gradle JGiven Plugin'
+        }
+    }
+}

--- a/jgiven-gradle-plugin/src/main/java/com/tngtech/jgiven/gradle/JGivenPlugin.java
+++ b/jgiven-gradle-plugin/src/main/java/com/tngtech/jgiven/gradle/JGivenPlugin.java
@@ -1,0 +1,91 @@
+package com.tngtech.jgiven.gradle;
+
+import com.google.common.collect.ImmutableMap;
+import com.tngtech.jgiven.impl.Config;
+import com.tngtech.jgiven.impl.util.WordUtil;
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.internal.IConventionAware;
+import org.gradle.api.plugins.ReportingBasePlugin;
+import org.gradle.api.reporting.ReportingExtension;
+import org.gradle.api.tasks.testing.Test;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class JGivenPlugin implements Plugin<Project> {
+    @Override
+    public void apply( final Project project ) {
+        project.getPluginManager().apply( ReportingBasePlugin.class );
+
+        addTaskExtension( project );
+        addReports( project );
+    }
+
+    private void addTaskExtension( Project project ) {
+        project.getTasks().withType( Test.class, new Action<Test>() {
+            @Override
+            public void execute( Test test ) {
+                applyTo( test );
+            }
+        } );
+    }
+
+    private void applyTo( Test test ) {
+        final String testName = test.getName();
+        final JGivenTaskExtension extension = test.getExtensions().create( "jgiven", JGivenTaskExtension.class );
+        final Project project = test.getProject();
+        ( (IConventionAware) extension ).getConventionMapping().map( "resultsDir", new Callable<File>() {
+            @Override
+            public File call() {
+                return project.file( String.valueOf( project.getBuildDir() ) + "/jgiven-results/" + testName );
+            }
+        } );
+
+        test.getOutputs().namedFiles( new Callable<Map<?, ?>>() {
+            @Override
+            public Map<String, File> call() throws Exception {
+                ImmutableMap.Builder<String, File> builder = ImmutableMap.builder();
+                File resultsDir = extension.getResultsDir();
+                if( resultsDir != null ) {
+                    builder.put( "jgiven.resultsDir", resultsDir );
+                }
+                return builder.build();
+            }
+        } );
+
+        test.prependParallelSafeAction( new Action<Task>() {
+            @Override
+            public void execute( Task task ) {
+                Test test = (Test) task;
+                test.systemProperty( Config.JGIVEN_REPORT_DIR, extension.getResultsDir().getAbsolutePath() );
+            }
+        } );
+    }
+
+    private void addReports( final Project project ) {
+        final ReportingExtension reportingExtension = project.getExtensions().findByType( ReportingExtension.class );
+        project.getTasks().withType( Test.class, new Action<Test>() {
+            @Override
+            public void execute( final Test test ) {
+                final JGivenReport reportTask = project.getTasks()
+                        .create( "jgiven" + WordUtil.capitalize( test.getName() ) + "Report", JGivenReport.class );
+                ( (IConventionAware) reportTask ).getConventionMapping().map( "results", new Callable<File>() {
+                    @Override
+                    public File call() {
+                        return test.getExtensions().getByType( JGivenTaskExtension.class ).getResultsDir();
+                    }
+                } );
+                ( (IConventionAware) reportTask ).getConventionMapping().map( "destination", new Callable<File>() {
+                    @Override
+                    public File call() {
+                        return reportingExtension.file( "jgiven/" + test.getName() );
+                    }
+                } );
+            }
+        } );
+    }
+}

--- a/jgiven-gradle-plugin/src/main/java/com/tngtech/jgiven/gradle/JGivenReport.java
+++ b/jgiven-gradle-plugin/src/main/java/com/tngtech/jgiven/gradle/JGivenReport.java
@@ -1,0 +1,47 @@
+package com.tngtech.jgiven.gradle;
+
+import com.tngtech.jgiven.report.ReportGenerator;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+
+@CacheableTask
+public class JGivenReport extends DefaultTask {
+    private File results;
+    private File destination;
+
+    @InputDirectory
+    @SkipWhenEmpty
+    @PathSensitive( PathSensitivity.NONE )
+    public File getResults() {
+        return results;
+    }
+
+    public void setResults( File results ) {
+        this.results = results;
+    }
+
+    @TaskAction
+    public void generate() throws Exception {
+        ReportGenerator generator = new ReportGenerator();
+        generator.setTargetDirectory( getDestination() );
+        generator.setSourceDirectory( getResults() );
+        generator.generate();
+    }
+
+    @OutputDirectory
+    public File getDestination() {
+        return destination;
+    }
+
+    public void setDestination( File destination ) {
+        this.destination = destination;
+    }
+}

--- a/jgiven-gradle-plugin/src/main/java/com/tngtech/jgiven/gradle/JGivenTaskExtension.java
+++ b/jgiven-gradle-plugin/src/main/java/com/tngtech/jgiven/gradle/JGivenTaskExtension.java
@@ -1,0 +1,15 @@
+package com.tngtech.jgiven.gradle;
+
+import java.io.File;
+
+public class JGivenTaskExtension {
+    private File resultsDir;
+
+    public File getResultsDir() {
+        return resultsDir;
+    }
+
+    public void setResultsDir( File resultsDir ) {
+        this.resultsDir = resultsDir;
+    }
+}

--- a/jgiven-gradle-plugin/src/test/java/com/tngtech/jgiven/gradle/JGivenPluginTest.java
+++ b/jgiven-gradle-plugin/src/test/java/com/tngtech/jgiven/gradle/JGivenPluginTest.java
@@ -1,0 +1,221 @@
+package com.tngtech.jgiven.gradle;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import com.google.common.io.Resources;
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.BeforeStage;
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.annotation.Quoted;
+import com.tngtech.jgiven.annotation.ScenarioState;
+import com.tngtech.jgiven.junit.ScenarioTest;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JGivenPluginTest extends ScenarioTest<JGivenPluginTest.Given, JGivenPluginTest.When, JGivenPluginTest.Then> {
+    @Rule
+    @ScenarioState
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Test
+    public void plugin_does_not_force_creation_of_buildDir_during_configuration() throws Exception {
+        given().the_plugin_is_applied();
+
+        when().a_build().with().the_task( "tasks" ).is_successful();
+
+        then().the_build_directory_has_not_been_created();
+    }
+
+    @Test
+    public void plugin_can_build_with_an_empty_project() throws Exception {
+        given().the_plugin_is_applied();
+
+        when().a_build().with().the_task( "build" ).is_successful();
+
+        then().all_tasks_have_been_executed();
+    }
+
+    @Test
+    public void jgiven_test_results_are_written_to_the_buildDir() throws IOException {
+        given()
+                .the_plugin_is_applied()
+                .and().there_are_JGiven_tests();
+
+        when()
+                .a_build().with().the_task( "test" ).is_successful();
+
+        then()
+                .the_JGiven_results_are_written_to( "build/jgiven-results/test" );
+
+    }
+
+    @Test
+    public void jgiven_test_results_can_be_written_to_custom_directory() throws IOException {
+        String customResultsDir = "build/jgiven-jsons";
+        given()
+                .the_plugin_is_applied()
+                .and().the_results_dir_is_set_to( customResultsDir )
+                .and().there_are_JGiven_tests();
+
+        when()
+                .a_build().with().the_task( "test" ).is_successful();
+
+        then()
+                .the_JGiven_results_are_written_to( customResultsDir );
+
+    }
+
+    @Test
+    public void jgiven_html_report_is_generated() throws IOException {
+        given()
+                .the_plugin_is_applied()
+                .and().there_are_JGiven_tests();
+
+        when()
+                .a_build().with()
+                .the_task( "test" ).and()
+                .the_task( "jgivenTestReport" ).is_successful();
+
+        then()
+                .the_JGiven_reports_are_written_to( "build/reports/jgiven/test" );
+
+    }
+
+    @Test
+    public void no_jgiven_results_no_report() throws IOException {
+
+        given()
+                .the_plugin_is_applied()
+                .and().there_are_JGiven_tests();
+
+        when()
+                .a_build().with()
+                .the_task( "jgivenTestReport" ).is_successful();
+
+        then()
+                .the_JGiven_reports_are_not_written_to( "build/reports/jgiven/test" );
+
+    }
+
+    public static class Given extends Stage<Given> {
+        @ExpectedScenarioState
+        private TemporaryFolder testProjectDir;
+
+        File buildFile;
+
+        @BeforeStage
+        private void setup() throws IOException {
+            buildFile = testProjectDir.newFile( "build.gradle" );
+        }
+
+        public Given the_plugin_is_applied() throws IOException {
+            Files.append( "plugins { id 'java'; id 'com.tngtech.jgiven.gradle-plugin' }\n", buildFile, Charsets.UTF_8 );
+            Files.append( "repositories { mavenCentral() }\n", buildFile, Charsets.UTF_8 );
+            Files.append( "dependencies { testCompile 'com.tngtech.jgiven:jgiven-junit:0.12.1' }\n", buildFile, Charsets.UTF_8 );
+            Files.append( "dependencies { testCompile 'junit:junit:4.12' }\n", buildFile, Charsets.UTF_8 );
+            return self();
+        }
+
+        public Given there_are_JGiven_tests() throws IOException {
+            testProjectDir.newFolder( "src", "test", "java" );
+            File scenario = testProjectDir.newFile( "src/test/java/SimpleScenario.java" );
+
+            Files.write( Resources.toByteArray( Resources.getResource( "SimpleScenario.java" ) ), scenario );
+
+            return self();
+        }
+
+        public Given the_results_dir_is_set_to( String dir ) throws IOException {
+            Files.append( "test { jgiven { resultsDir = file('" + dir + "') } }\n", buildFile, Charsets.UTF_8 );
+            return self();
+        }
+    }
+
+    public static class When extends Stage<When> {
+        @ExpectedScenarioState
+        private TemporaryFolder testProjectDir;
+        @ProvidedScenarioState
+        private BuildResult result;
+        @ProvidedScenarioState
+        List<String> tasks = new ArrayList<>();
+
+        public When the_task( @Quoted String task ) {
+            tasks.add( task );
+            return self();
+        }
+
+        public When a_build() {
+            return self();
+        }
+
+        public When is_successful() {
+            result = GradleRunner.create()
+                    .withProjectDir( testProjectDir.getRoot() )
+                    .withArguments( tasks )
+                    .withPluginClasspath()
+                    .build();
+            return self();
+        }
+    }
+
+    public static class Then extends Stage<Then> {
+        @ExpectedScenarioState
+        private BuildResult result;
+        @ExpectedScenarioState
+        private TemporaryFolder testProjectDir;
+        @ScenarioState
+        List<String> tasks;
+
+        public Then the_build_directory_has_not_been_created() {
+            assertThat( new File( testProjectDir.getRoot(), "build" ) ).doesNotExist();
+            return self();
+        }
+
+        public Then all_tasks_have_been_executed() {
+            for( String task : tasks ) {
+                assertThat( result.task( ":" + task ).getOutcome() ).isEqualTo( TaskOutcome.SUCCESS );
+            }
+            return self();
+        }
+
+        public Then the_JGiven_results_are_written_to( String destination ) {
+            assertDirectoryContainsFilesOfType( destination, "json" );
+            return self();
+        }
+
+        public Then the_JGiven_reports_are_written_to( String reportDirectory ) {
+            assertDirectoryContainsFilesOfType( reportDirectory, "html" );
+            return self();
+        }
+
+        private void assertDirectoryContainsFilesOfType( String destination, final String extension ) {
+            File destinationDir = new File( testProjectDir.getRoot(), destination );
+            assertThat( destinationDir ).isDirectory();
+            assertThat( destinationDir.listFiles( new FilenameFilter() {
+                @Override
+                public boolean accept( File dir, String name ) {
+                    return name.endsWith( "." + extension );
+                }
+            } ) ).isNotEmpty();
+        }
+
+        public Then the_JGiven_reports_are_not_written_to( String destination ) {
+            File destinationDir = new File( testProjectDir.getRoot(), destination );
+            assertThat( destinationDir ).doesNotExist();
+            return self();
+        }
+    }
+}

--- a/jgiven-gradle-plugin/src/test/resources/SimpleScenario.java
+++ b/jgiven-gradle-plugin/src/test/resources/SimpleScenario.java
@@ -1,0 +1,19 @@
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.junit.SimpleScenarioTest;
+import org.junit.Test;
+
+public class SimpleScenario extends SimpleScenarioTest<SimpleScenario.TestStep> {
+
+    @Test
+    public void some_scenario() {
+        given().all_is_good();
+
+        then().all_is_good();
+    }
+
+    public static class TestStep extends Stage<TestStep> {
+        public TestStep all_is_good() {
+            return self();
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = 'jgiven'
 
 include ':jgiven-core'
 include ':jgiven-maven-plugin'
+include ':jgiven-gradle-plugin'
 include ':jgiven-junit'
 include ':jgiven-testng'
 include ':jgiven-spring'


### PR DESCRIPTION
This would fix #98.

The plugin currently adds a `jgiven<Test Task name>Report` task
 for each test task and generates the report (if JGiven JSON files have been generated)
 to `build/reports/jgiven/<Test Task Name>`.

Things which still need some work:

 - Add the possibility to generate other reports apart from the html
 report
 - Add some more tests regarding up to date checking
 - Should it be possible to generate one report for all tests executed
   in
   - a multimodule build
   - different test tasks
 - Use the built version of JGiven in the tests instead of the last
   released version
 - Polish the code