### PR TITLE
Enable building Maven plugin on Windows

### DIFF
--- a/jgiven-maven-plugin/build.gradle
+++ b/jgiven-maven-plugin/build.gradle
@@ -18,11 +18,11 @@ task generatePom(type: Copy, dependsOn: copyClasses) {
     expand(version: project.version)
 }
 
-task generateMavenPlugin(type: Exec, dependsOn: generatePom) {
+task generateMavenPlugin(type: CrossPlatformExec, dependsOn: generatePom) {
     // currenlty it seems to be the more or less only clean solution
     // to generate a plugin.xml file to use maven directly
     // if anyone has a better solution please let us know!
-	commandLine 'mvn', '-U', '-f', 'build/maven/pom.xml', 'plugin:descriptor'
+    buildCommand 'mvn', '-U', '-f', 'build/maven/pom.xml', 'plugin:descriptor'
 }
 
 generateMavenPlugin.onlyIf {
@@ -52,3 +52,15 @@ task copyPom(type: Copy, dependsOn: generatePom) {
 }
 
 jar.dependsOn copyMavenPlugin, copyPom
+
+class CrossPlatformExec extends Exec {
+    void buildCommand(String command, String... commandArgs) {
+        if(org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+            executable = 'cmd'
+            args = ['/c', command]
+        } else {
+            executable = command
+        }
+        args(commandArgs.toList());
+    }
+}


### PR DESCRIPTION
this extends the CrossPlatformExec concept for other modules to the maven plugin