### PR TITLE
Document Maven report options

### DIFF
--- a/docs/report_generation.adoc
+++ b/docs/report_generation.adoc
@@ -45,7 +45,7 @@ http://jgiven.org/jgiven-report/html5/[HTML report of JGiven itself]
 
 For Maven there exists a plugin that can be used as follows:
 
-[source,maven,subs="verbatim,attributes"]
+[source,xml,subs="verbatim,attributes"]
 ----
 <build>
   <plugins>
@@ -67,6 +67,37 @@ For Maven there exists a plugin that can be used as follows:
  </plugins>
 </build>
 ----
+
+You can add the following configuration options (like the _format_ configuration above) to customize the report.
+All of them are optional.
+
+[cols="1,3"]
+.Configuration Options for Reports
+|===
+|Option |Description
+
+|format
+|The format of the generated report. Can be _html_ or _text_. Default: _html_
+
+|title
+|The title of the generated report. Default: _JGiven Report_
+
+|customCssFile
+|Custom CSS file to customize the HTML report. Default: _src/test/resources/jgiven/custom.css_
+
+|customJsFile
+|Custom JS file to customize the HTML report. Default: _src/test/resources/jgiven/custom.js_
+
+|excludeEmptyScenarios
+|Whether or not to exclude empty scenarios, i.e. scenarios without any steps, from the report. Default: _false_
+
+|outputDirectory
+|Directory where the reports are generated to. Default: _${project.build.directory}/jgiven-reports/html_
+
+|sourceDirectory
+|Directory to read the JSON report files from. Default: _${project.build.directory}/jgiven-reports/json_
+
+|===
 
 Now run:
 


### PR DESCRIPTION
Given a user's question in #316 about parameters for report generation, I updated the documentation regarding the Maven plugin. 

This duplicates the documentation available in the source code and the maven plugin, but this might be easier to find for the users.