### PR TITLE
fix #318

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/format/POJOAnnotationFormatter.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/format/POJOAnnotationFormatter.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.base.Function;
@@ -31,6 +32,10 @@ public class POJOAnnotationFormatter
 
     @Override
     public String format( Object obj, POJOFormat annotation ) {
+        if( Objects.isNull( obj ) ) {
+            return "null";
+        }
+
         List<Field> fields = getFields( obj.getClass(), annotation );
         boolean[] nonNullColumns = new boolean[fields.size()];
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/format/POJOAnnotationFormatter.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/format/POJOAnnotationFormatter.java
@@ -32,7 +32,7 @@ public class POJOAnnotationFormatter
 
     @Override
     public String format( Object obj, POJOFormat annotation ) {
-        if( Objects.isNull( obj ) ) {
+        if( obj == null ) {
             return "null";
         }
 

--- a/jgiven-examples/build.gradle
+++ b/jgiven-examples/build.gradle
@@ -1,5 +1,6 @@
 
 dependencies {
+	compile project(':jgiven-core')
     testCompile project(':jgiven-junit')
     testCompile project(':jgiven-spring')
     testCompile project(':jgiven-tests')

--- a/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/annotation/AddressFormat.java
+++ b/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/annotation/AddressFormat.java
@@ -1,0 +1,21 @@
+package com.tngtech.jgiven.examples.datatable.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.tngtech.jgiven.annotation.Format;
+import com.tngtech.jgiven.annotation.NamedFormat;
+import com.tngtech.jgiven.annotation.NamedFormats;
+import com.tngtech.jgiven.examples.datatable.format.ToUpperCaseFormatter;
+
+//@formatter:off
+@NamedFormats({
+    @NamedFormat( name = "street"),
+    @NamedFormat( name = "city", format = @Format( value = ToUpperCaseFormatter.class )),
+    @NamedFormat( name = "zipCode"),
+    @NamedFormat( name = "state", format = @Format( value = ToUpperCaseFormatter.class )),
+    @NamedFormat( name = "country", format = @Format( value = ToUpperCaseFormatter.class )),
+})
+//@formatter:on
+@Retention( RetentionPolicy.RUNTIME )
+public @interface AddressFormat {}

--- a/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/annotation/AddressReducedPOJOFormat.java
+++ b/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/annotation/AddressReducedPOJOFormat.java
@@ -1,0 +1,16 @@
+package com.tngtech.jgiven.examples.datatable.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.tngtech.jgiven.annotation.POJOFormat;
+
+// @formatter:off
+@POJOFormat(
+    fieldFormatsAnnotation = AddressFormat.class,
+    includeFields = {"zipCode", "city", "country"},
+    fieldSeparator = "/"
+)
+// @formatter:on
+@Retention( RetentionPolicy.RUNTIME )
+public @interface AddressReducedPOJOFormat {}

--- a/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/annotation/CustomerFormat.java
+++ b/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/annotation/CustomerFormat.java
@@ -1,0 +1,19 @@
+package com.tngtech.jgiven.examples.datatable.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.tngtech.jgiven.annotation.Format;
+import com.tngtech.jgiven.annotation.NamedFormat;
+import com.tngtech.jgiven.annotation.NamedFormats;
+import com.tngtech.jgiven.examples.datatable.format.ToUpperCaseFormatter;
+
+//@formatter:off
+@NamedFormats({
+    @NamedFormat( name = "name", format = @Format( value = ToUpperCaseFormatter.class ) ),
+    @NamedFormat( name = "email", formatAnnotation = QuotedCustomFormatAnnotationChain.class ),
+    @NamedFormat( name = "shippingAddress", formatAnnotation = AddressReducedPOJOFormat.class ),
+})
+//@formatter:on
+@Retention( RetentionPolicy.RUNTIME )
+public @interface CustomerFormat {}

--- a/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/annotation/QuotedCustomFormatAnnotationChain.java
+++ b/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/annotation/QuotedCustomFormatAnnotationChain.java
@@ -1,0 +1,16 @@
+package com.tngtech.jgiven.examples.datatable.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.tngtech.jgiven.annotation.Formatf;
+import com.tngtech.jgiven.annotation.Quoted;
+
+@Formatf( value = "(quoted by custom format annotation) %s" )
+@Quoted
+@Retention( RetentionPolicy.RUNTIME )
+@Target( { ElementType.PARAMETER, ElementType.ANNOTATION_TYPE, ElementType.FIELD } )
+public @interface QuotedCustomFormatAnnotationChain {
+}

--- a/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/annotation/UpperCasedCustomFormatAnnotationChain.java
+++ b/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/annotation/UpperCasedCustomFormatAnnotationChain.java
@@ -1,0 +1,17 @@
+package com.tngtech.jgiven.examples.datatable.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.tngtech.jgiven.annotation.Format;
+import com.tngtech.jgiven.annotation.Formatf;
+import com.tngtech.jgiven.examples.datatable.format.ToUpperCaseFormatter;
+
+@Formatf( value = "(uppercased by custom format annotation) %s" )
+@Format( value = ToUpperCaseFormatter.class )
+@Retention( RetentionPolicy.RUNTIME )
+@Target( { ElementType.PARAMETER, ElementType.ANNOTATION_TYPE, ElementType.FIELD } )
+public @interface UpperCasedCustomFormatAnnotationChain {
+}

--- a/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/format/ToUpperCaseFormatter.java
+++ b/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/format/ToUpperCaseFormatter.java
@@ -1,0 +1,14 @@
+package com.tngtech.jgiven.examples.datatable.format;
+
+import com.tngtech.jgiven.format.ArgumentFormatter;
+
+public class ToUpperCaseFormatter implements ArgumentFormatter<String> {
+    @Override
+    public String format( String value, String... args ) {
+        if( value == null ) {
+            return "";
+        }
+
+        return value.toUpperCase();
+    }
+}

--- a/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/model/Address.java
+++ b/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/model/Address.java
@@ -1,0 +1,73 @@
+package com.tngtech.jgiven.examples.datatable.model;
+
+public class Address {
+    String street;
+    String zipCode;
+    String city;
+    String state;
+    String country;
+
+    private Address() {
+        super();
+    }
+
+    public static class AddressBuilder {
+        Address instance;
+
+        public AddressBuilder street( String street ) {
+            this.instance.street = street;
+            return this;
+        }
+
+        public AddressBuilder zipCode( String zipCode ) {
+            this.instance.zipCode = zipCode;
+            return this;
+        }
+
+        public AddressBuilder city( String city ) {
+            this.instance.city = city;
+            return this;
+        }
+
+        public AddressBuilder state( String state ) {
+            this.instance.state = state;
+            return this;
+        }
+
+        public AddressBuilder country( String country ) {
+            this.instance.country = country;
+            return this;
+        }
+
+        public Address build() {
+            return instance;
+        }
+    }
+
+    public static AddressBuilder builder() {
+        AddressBuilder b = new AddressBuilder();
+        b.instance = new Address();
+        return b;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getZipCode() {
+        return zipCode;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+}

--- a/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/model/Customer.java
+++ b/jgiven-examples/src/main/java/com/tngtech/jgiven/examples/datatable/model/Customer.java
@@ -1,0 +1,40 @@
+package com.tngtech.jgiven.examples.datatable.model;
+
+import com.tngtech.jgiven.annotation.Formatf;
+import com.tngtech.jgiven.annotation.Quoted;
+
+public class Customer {
+    String name;
+
+    @Formatf( value = "(quoted at POJO field level) %s" )
+    @Quoted
+    String email;
+
+    Address shippingAddress;
+
+    public Customer( String name, String email ) {
+        super();
+        this.name = name;
+        this.email = email;
+    }
+
+    public Customer( String name, String email, Address shippingAddress ) {
+        super();
+        this.name = name;
+        this.email = email;
+        this.shippingAddress = shippingAddress;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Address getShippingAddress() {
+        return shippingAddress;
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/datatable/DataTableExamples.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/datatable/DataTableExamples.java
@@ -3,53 +3,20 @@ package com.tngtech.jgiven.examples.datatable;
 import static com.tngtech.jgiven.annotation.Table.HeaderType.VERTICAL;
 import static java.util.Arrays.asList;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 import java.util.List;
 
 import org.junit.Test;
 
 import com.tngtech.jgiven.Stage;
-import com.tngtech.jgiven.annotation.Format;
-import com.tngtech.jgiven.annotation.Formatf;
 import com.tngtech.jgiven.annotation.NamedFormat;
-import com.tngtech.jgiven.annotation.NamedFormats;
-import com.tngtech.jgiven.annotation.Quoted;
 import com.tngtech.jgiven.annotation.Table;
-import com.tngtech.jgiven.format.ArgumentFormatter;
+import com.tngtech.jgiven.examples.datatable.annotation.CustomerFormat;
+import com.tngtech.jgiven.examples.datatable.annotation.UpperCasedCustomFormatAnnotationChain;
+import com.tngtech.jgiven.examples.datatable.model.Address;
+import com.tngtech.jgiven.examples.datatable.model.Customer;
 import com.tngtech.jgiven.junit.SimpleScenarioTest;
 
 public class DataTableExamples extends SimpleScenarioTest<DataTableExamples.DataTableStage> {
-
-    public static class ToUpperCaseFormatter implements ArgumentFormatter<String> {
-        @Override
-        public String format( String value, String... args ) {
-            if( value == null ) {
-                return "";
-            }
-
-            return value.toUpperCase();
-        }
-    }
-
-    @Formatf( value = "(uppercased by custom format annotation) %s" )
-    @Format( value = ToUpperCaseFormatter.class )
-    @Retention( RetentionPolicy.RUNTIME )
-    @Target( { ElementType.PARAMETER, ElementType.ANNOTATION_TYPE, ElementType.FIELD } )
-    public static @interface UpperCasedCustomFormatAnnotationChain {}
-
-    @Formatf( value = "(quoted by custom format annotation) %s" )
-    @Quoted
-    @Retention( RetentionPolicy.RUNTIME )
-    @Target( { ElementType.PARAMETER, ElementType.ANNOTATION_TYPE, ElementType.FIELD } )
-    static @interface QuotedCustomFormatAnnotationChain {}
-
-    @NamedFormats( { @NamedFormat( name = "name", format = @Format( value = ToUpperCaseFormatter.class ) ),
-        @NamedFormat( name = "email", formatAnnotation = QuotedCustomFormatAnnotationChain.class ) } )
-    @Retention( RetentionPolicy.RUNTIME )
-    public static @interface TestCustomerFieldFormatSet {}
 
     static class DataTableStage extends Stage<DataTableStage> {
 
@@ -62,7 +29,7 @@ public class DataTableExamples extends SimpleScenarioTest<DataTableExamples.Data
             return self();
         }
 
-        public DataTableStage a_list_of_POJOs_is_used_as_parameters( @Table TestCustomer... testCustomer ) {
+        public DataTableStage a_list_of_POJOs_is_used_as_parameters( @Table Customer... testCustomer ) {
             return self();
         }
 
@@ -70,22 +37,22 @@ public class DataTableExamples extends SimpleScenarioTest<DataTableExamples.Data
                 @Table( fieldsFormat = {
                     @NamedFormat( name = "name", formatAnnotation = UpperCasedCustomFormatAnnotationChain.class ),
                     @NamedFormat( name = "email" )
-                } ) TestCustomer... testCustomer ) {
+                } ) Customer... testCustomer ) {
             return self();
         }
 
         public DataTableStage a_list_of_POJOs_is_used_as_parameters_and_some_fields_are_formatted_using_a_predefined_set_of_named_formats(
-                @Table( fieldsFormatSetAnnotation = TestCustomerFieldFormatSet.class ) TestCustomer... testCustomer ) {
+                @Table( fieldsFormatSetAnnotation = CustomerFormat.class ) Customer... testCustomer ) {
             return self();
         }
 
         public DataTableStage a_list_of_POJOs_is_used_as_parameters_with_header_type_VERTICAL(
-                @Table( header = VERTICAL ) TestCustomer... testCustomer ) {
+                @Table( header = VERTICAL ) Customer... testCustomer ) {
             return self();
         }
 
         public DataTableStage a_list_of_POJOs_is_used_as_parameters_with_header_type_VERTICAL_and_numbered_columns(
-                @Table( header = VERTICAL, numberedColumns = true ) TestCustomer... testCustomer ) {
+                @Table( header = VERTICAL, numberedColumns = true ) Customer... testCustomer ) {
             return self();
         }
 
@@ -93,29 +60,16 @@ public class DataTableExamples extends SimpleScenarioTest<DataTableExamples.Data
 
         }
 
-        public void a_single_POJO_is_used_as_parameters( @Table( header = VERTICAL ) TestCustomer testCustomer ) {}
+        public void a_single_POJO_is_used_as_parameters( @Table( header = VERTICAL ) Customer testCustomer ) {}
 
-        public void a_list_of_POJOs_with_numbered_rows( @Table( numberedRows = true ) TestCustomer... testCustomer ) {}
+        public void a_list_of_POJOs_with_numbered_rows( @Table( numberedRows = true ) Customer... testCustomer ) {}
 
         public void a_list_of_POJOs_with_numbered_rows_and_custom_header(
-                @Table( numberedRowsHeader = "Counter" ) TestCustomer... testCustomer ) {}
+                @Table( numberedRowsHeader = "Counter" ) Customer... testCustomer ) {}
 
         public void a_two_dimensional_array_with_numbered_rows(
                 @Table( numberedRows = true, columnTitles = "t" ) Object[][] testCustomer ) {}
 
-    }
-
-    static class TestCustomer {
-        String name;
-
-        @Formatf( value = "(quoted at POJO field level) %s" )
-        @Quoted
-        String email;
-
-        public TestCustomer( String name, String email ) {
-            this.name = name;
-            this.email = email;
-        }
     }
 
     @Test
@@ -132,48 +86,56 @@ public class DataTableExamples extends SimpleScenarioTest<DataTableExamples.Data
 
     @Test
     public void a_list_of_POJOs_can_be_represented_as_data_tables() {
-        given().a_list_of_POJOs_is_used_as_parameters( new TestCustomer( "John Doe", "john@doe.com" ),
-            new TestCustomer( "Jane Roe", "jane@roe.com" ) );
+        given().a_list_of_POJOs_is_used_as_parameters( new Customer( "John Doe", "john@doe.com" ),
+            new Customer( "Jane Roe", "jane@roe.com" ) );
     }
 
     @Test
     public void a_list_of_POJOs_can_be_represented_as_formatted_data_tables() {
         given().a_list_of_POJOs_is_used_as_parameters_and_some_fields_are_formatted_using_inline_specified_named_formats(
-            new TestCustomer( "John Doe", "john@doe.com" ), new TestCustomer( "Jane Roe", "jane@roe.com" ) ).and()
+            new Customer( "John Doe", "john@doe.com" ), new Customer( "Jane Roe", "jane@roe.com" ) ).and()
             .a_list_of_POJOs_is_used_as_parameters_and_some_fields_are_formatted_using_a_predefined_set_of_named_formats(
-                new TestCustomer( "John Doe", "john@doe.com" ), new TestCustomer( "Jane Roe", "jane@roe.com" ) ).and()
+                new Customer( "John Doe", "john@doe.com" ),
+                new Customer( "Jane Roe", "jane@roe.com",
+                    Address.builder()
+                        .street( "4988 Elk Street" )
+                        .zipCode( "90017" )
+                        .city( "Los Angeles" )
+                        .state( "California" )
+                        .country( "US" )
+                        .build() ) )
+            .and()
             .a_list_of_POJOs_is_used_as_parameters_and_some_fields_are_formatted_using_a_predefined_set_of_named_formats(
-                new TestCustomer( "John Doe", null ), new TestCustomer( null, "jane@roe.com" ) )
-            ;
+                new Customer( "John Doe", null ), new Customer( null, "jane@roe.com" ) );
     }
 
     @Test
     public void a_list_of_POJOs_can_be_represented_as_a_data_table_with_a_vertical_header() {
         given().a_list_of_POJOs_is_used_as_parameters_with_header_type_VERTICAL(
-            new TestCustomer( "John Doe", "john@doe.com" ), new TestCustomer( "Jane Roe", "jane@roe.com" ) );
+            new Customer( "John Doe", "john@doe.com" ), new Customer( "Jane Roe", "jane@roe.com" ) );
     }
 
     @Test
     public void a_list_of_POJOs_can_be_represented_as_a_data_table_with_a_vertical_header_and_numbered_columns() {
         given().a_list_of_POJOs_is_used_as_parameters_with_header_type_VERTICAL_and_numbered_columns(
-            new TestCustomer( "John Doe", "john@doe.com" ), new TestCustomer( "Jane Roe", "jane@roe.com" ) );
+            new Customer( "John Doe", "john@doe.com" ), new Customer( "Jane Roe", "jane@roe.com" ) );
     }
 
     @Test
     public void a_single_POJO_can_be_represented_as_a_data_table() {
-        given().a_single_POJO_is_used_as_parameters( new TestCustomer( "Jane Roe", "jane@roe.com" ) );
+        given().a_single_POJO_is_used_as_parameters( new Customer( "Jane Roe", "jane@roe.com" ) );
     }
 
     @Test
     public void parameter_tables_can_have_numbered_rows() {
-        given().a_list_of_POJOs_with_numbered_rows( new TestCustomer( "John Doe", "john@doe.com" ),
-            new TestCustomer( "Jane Roe", "jane@roe.com" ), new TestCustomer( "Lee Smith", "lee@smith.com" ) );
+        given().a_list_of_POJOs_with_numbered_rows( new Customer( "John Doe", "john@doe.com" ),
+            new Customer( "Jane Roe", "jane@roe.com" ), new Customer( "Lee Smith", "lee@smith.com" ) );
     }
 
     @Test
     public void parameter_tables_can_have_numbered_rows_with_custom_headers() {
-        given().a_list_of_POJOs_with_numbered_rows_and_custom_header( new TestCustomer( "John Doe", "john@doe.com" ),
-            new TestCustomer( "Jane Roe", "jane@roe.com" ), new TestCustomer( "Lee Smith", "lee@smith.com" ) );
+        given().a_list_of_POJOs_with_numbered_rows_and_custom_header( new Customer( "John Doe", "john@doe.com" ),
+            new Customer( "Jane Roe", "jane@roe.com" ), new Customer( "Lee Smith", "lee@smith.com" ) );
     }
 
     @Test


### PR DESCRIPTION
- [x] fix POJOAnnotationFormatter to return literal string "null" when given object is null
- [x] complete datatable examples to test this behavior
- [x] migrate datatable examples model/format/annotation classes from src/test/java to src/main/java