### PR TITLE
fixed logger to use in Html5ReportGenerator

### DIFF
--- a/jgiven-html5-report/src/main/java/com/tngtech/jgiven/report/html5/Html5ReportGenerator.java
+++ b/jgiven-html5-report/src/main/java/com/tngtech/jgiven/report/html5/Html5ReportGenerator.java
@@ -35,7 +35,7 @@ import com.tngtech.jgiven.report.model.ScenarioModel;
 import com.tngtech.jgiven.report.model.StepModel;
 
 public class Html5ReportGenerator extends AbstractReportGenerator {
-    private static final Logger log = LoggerFactory.getLogger( ReportGenerator.class );
+    private static final Logger log = LoggerFactory.getLogger( Html5ReportGenerator.class );
     private static final int MAX_BATCH_SIZE = 100;
 
     private PrintStream fileStream;


### PR DESCRIPTION
With using a logger created for this class, the log messages will appear associated with the class Html5ReportGenerator in the logfiles.