### PR TITLE
Allow for partial application of paramaters when using placeholders.

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/StepFormatter.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/StepFormatter.java
@@ -153,6 +153,8 @@ public class StepFormatter {
         boolean dropNextWhitespace = false;
         StringBuilder currentWords = new StringBuilder();
 
+        boolean performedReplacement = false;
+
         for( int i = 0; i < stepDescription.length(); i++ ) {
 
             boolean dollarMatch = stepDescription.charAt( i ) == '$';
@@ -166,6 +168,7 @@ public class StepFormatter {
             boolean singleDollarCountIndexExists = singlePlaceholderCounter < arguments.size();
 
             if( dollarMatch ) {
+                performedReplacement = true;
                 // e.g $$
                 if( escapedDollarMatch ) {
                     formattedWords.add( new Word( "$" ) );
@@ -216,7 +219,9 @@ public class StepFormatter {
         }
 
         flushCurrentWord( currentWords, formattedWords, false );
-        formattedWords.addAll( getRemainingArguments( usedArguments ) );
+        if (!performedReplacement) {
+            formattedWords.addAll( getRemainingArguments( usedArguments ) );
+        }
         return formattedWords;
     }
 

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/report/model/StepFormatterTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/report/model/StepFormatterTest.java
@@ -50,6 +50,9 @@ public class StepFormatterTest {
                 { "$2 $1",         asList( "strA", "strB" ), asList("a", "b"),   "b a" },
                 { "$]",            asList( "strA"),          asList( "a" ),      "a ]" },
                 { "foo $]",        asList( "strA" ),         asList( "a" ),      "foo a ]" },
+                { "foo$",          asList( "strA", "strB"),  asList( "a", "b"),  "foo a"},
+                { "$2",            asList( "strA", "strB"),  asList( "a", "b"),  "b"},
+                { "$",             asList( "strA", "strB"),  asList( "a", "b"),  "a"}
         };
         // @formatter:on
 


### PR DESCRIPTION
It seemed weird that JGiven would output every parameter in a formatted @As annotation when only a specific parameter is needed.  This patch addresses that.

All but one test  of the StepFormatter is passing.  This one fails:
https://github.com/TNG/JGiven/blob/master/jgiven-core/src/test/java/com/tngtech/jgiven/report/model/StepFormatterTest.java#L88

```
{ "$$ foo", asList( "bool" ), asList( true ), null, "", "\\$ foo true" },
```
I'm not sure why this is desirable, maybe this is just a side effect of how the replacement logic was implemented in the first place?  If this is the case, can we change the behavior of this test to be:

```
{ "$$ foo", asList( "bool" ), asList( true ), null, "", "\\$ foo" },
```
?