### PR TITLE
@JGivenStage enforces prototype mode to ensure a fresh instance 

### DIFF
--- a/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/JGivenStage.java
+++ b/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/JGivenStage.java
@@ -6,10 +6,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 /**
- * Annotation that marks a bean as JGiven Stage.
+ * Annotation that marks a bean as JGiven Stage. This component will be in created in prototype scope
+ * to ensure that each test run receives a fresh (empty) instance of the bean.
  *
  * @since 0.8.0
  */
@@ -17,6 +20,7 @@ import org.springframework.stereotype.Component;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public @interface JGivenStage {
 
     /**

--- a/jgiven-spring/src/test/java/com/tngtech/jgiven/integration/spring/test/SpringRuleFreshInstanceForEachDataproviderTest.java
+++ b/jgiven-spring/src/test/java/com/tngtech/jgiven/integration/spring/test/SpringRuleFreshInstanceForEachDataproviderTest.java
@@ -1,0 +1,26 @@
+package com.tngtech.jgiven.integration.spring.test;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.jgiven.integration.spring.SpringRuleScenarioTest;
+import com.tngtech.jgiven.integration.spring.config.TestSpringConfig;
+import com.tngtech.jgiven.integration.spring.test.proxy.ThenNewInstanceStage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+
+@RunWith( DataProviderRunner.class )
+@ContextConfiguration( classes = TestSpringConfig.class )
+public class SpringRuleFreshInstanceForEachDataproviderTest
+        extends SpringRuleScenarioTest<SimpleTestSpringSteps, SimpleTestSpringSteps, ThenNewInstanceStage> {
+
+    private static Object previousInstance;
+
+    @Test
+    @DataProvider( { "John", "Doe" } )
+    public void spring_should_have_new_stage_instance_for_each_test_case( String ignored ) {
+        given().a_step_that_is_a_spring_component();
+        then().the_step_instance_is_not_the_same_as_on_previous_run( previousInstance );
+        previousInstance = then();
+    }
+}

--- a/jgiven-spring/src/test/java/com/tngtech/jgiven/integration/spring/test/SpringRuleFreshInstanceForEachTestTest.java
+++ b/jgiven-spring/src/test/java/com/tngtech/jgiven/integration/spring/test/SpringRuleFreshInstanceForEachTestTest.java
@@ -1,0 +1,34 @@
+package com.tngtech.jgiven.integration.spring.test;
+
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.jgiven.integration.spring.SpringRuleScenarioTest;
+import com.tngtech.jgiven.integration.spring.config.TestSpringConfig;
+import com.tngtech.jgiven.integration.spring.test.proxy.ThenNewInstanceStage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+
+@RunWith( DataProviderRunner.class )
+@ContextConfiguration( classes = TestSpringConfig.class )
+public class SpringRuleFreshInstanceForEachTestTest
+        extends SpringRuleScenarioTest<SimpleTestSpringSteps, SimpleTestSpringSteps, ThenNewInstanceStage> {
+
+    private static Object previousInstance;
+
+    @Test
+    public void spring_should_have_new_stage_instance_for_each_test_case_A() {
+        checkStepInstance();
+    }
+
+    @Test
+    public void spring_should_have_new_stage_instance_for_each_test_case_B() {
+        checkStepInstance();
+    }
+
+    private void checkStepInstance() {
+        given().a_step_that_is_a_spring_component();
+        then().the_step_instance_is_not_the_same_as_on_previous_run( previousInstance );
+        previousInstance = then();
+    }
+
+}

--- a/jgiven-spring/src/test/java/com/tngtech/jgiven/integration/spring/test/proxy/ThenNewInstanceStage.java
+++ b/jgiven-spring/src/test/java/com/tngtech/jgiven/integration/spring/test/proxy/ThenNewInstanceStage.java
@@ -1,0 +1,16 @@
+package com.tngtech.jgiven.integration.spring.test.proxy;
+
+import com.tngtech.jgiven.annotation.Hidden;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JGivenStage
+public class ThenNewInstanceStage {
+
+    public void the_step_instance_is_not_the_same_as_on_previous_run( @Hidden Object previousInstance ) {
+        if( previousInstance != null ) {
+            assertThat( this ).isNotSameAs( previousInstance );
+        }
+    }
+}


### PR DESCRIPTION
There is added JavaDoc and two test cases. I needed to store a reference to the previous step, so I added a private static field to make it work.

Any ideas how to improve this? Should the documentation be enhanced?

If the answers are "no" it's ready to be merged from my point of view.

closes #362