### PR TITLE
Make @DoNotIntercept not trigger stage changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Backwards Incompatible Changes
 
 * Java 7 is not supported anymore
+* Calling stage methods annotated with `@DoNotIntercept` or declared within `java.lang.Object` will not trigger
+a stage change anymore [#385](https://github.com/TNG/JGiven/pull/385)
 
 ## Fixed Issues
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/StepInterceptorImpl.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/StepInterceptorImpl.java
@@ -1,6 +1,5 @@
 package com.tngtech.jgiven.impl.intercept;
 
-import static com.tngtech.jgiven.report.model.InvocationMode.DO_NOT_INTERCEPT;
 import static com.tngtech.jgiven.report.model.InvocationMode.NORMAL;
 import static com.tngtech.jgiven.report.model.InvocationMode.PENDING;
 import static com.tngtech.jgiven.report.model.InvocationMode.SKIPPED;
@@ -86,10 +85,6 @@ public class StepInterceptorImpl implements StepInterceptor {
 
         InvocationMode mode = getInvocationMode( receiver, method );
 
-        if( mode == DO_NOT_INTERCEPT ) {
-            return invoker.proceed();
-        }
-
         boolean hasNestedSteps = method.isAnnotationPresent( NestedSteps.class );
 
         boolean handleMethod = shouldHandleMethod( method );
@@ -138,14 +133,9 @@ public class StepInterceptorImpl implements StepInterceptor {
     }
 
     private boolean shouldInterceptMethod( Method method ) {
-        if( !interceptingEnabled ) {
-            return false;
-        }
-
-        if( method.getDeclaringClass().equals( Object.class ) ) {
-            return false;
-        }
-        return true;
+        return interceptingEnabled
+                && method.getDeclaringClass() != Object.class
+                && !method.isAnnotationPresent(DoNotIntercept.class);
     }
 
     protected Object handleThrowable( Object receiver, Method method, Throwable t, long durationInNanos, boolean handleMethod )
@@ -175,10 +165,6 @@ public class StepInterceptorImpl implements StepInterceptor {
     }
 
     protected InvocationMode getInvocationMode( Object receiver, Method method ) {
-        if( method.getDeclaringClass() == Object.class || method.isAnnotationPresent( DoNotIntercept.class ) ) {
-            return DO_NOT_INTERCEPT;
-        }
-
         if( !methodExecutionEnabled ) {
             return SKIPPED;
         }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/InvocationMode.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/InvocationMode.java
@@ -5,8 +5,7 @@ public enum InvocationMode {
     NESTED,
     FAILED,
     SKIPPED,
-    PENDING,
-    DO_NOT_INTERCEPT;
+    PENDING;
 
     public StepStatus toStepStatus() {
         switch( this ) {

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ScenarioExecutorTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ScenarioExecutorTest.java
@@ -126,6 +126,21 @@ public class ScenarioExecutorTest {
         assertThat( i ).isEqualTo( 5 );
     }
 
+    @Test
+    public void DoNotIntercept_methods_do_not_trigger_a_stage_change() {
+        ScenarioExecutor executor = new ScenarioExecutor();
+        AfterStageStep withAfterStage = executor.addStage( AfterStageStep.class );
+        withAfterStage.after_stage_was_not_yet_executed();
+        DoNotInterceptClass doNotIntercept = executor.addStage( DoNotInterceptClass.class );
+        executor.startScenario( "Test" );
+
+        doNotIntercept.an_unintercepted_step();
+        assertThat(withAfterStage.afterStageExecuted).as("@AfterStage was executed").isFalse();
+
+        doNotIntercept.an_intercepted_step();
+        assertThat(withAfterStage.afterStageExecuted).as("@AfterStage was executed").isTrue();
+    }
+
     static class TestClass {
         @ScenarioStage
         TestStep step;
@@ -232,6 +247,13 @@ public class ScenarioExecutorTest {
     static class DoNotInterceptClass {
         public void a_failing_step() {
             assertThat( true ).isFalse();
+        }
+
+        public void an_intercepted_step() {
+        }
+
+        @DoNotIntercept
+        public void an_unintercepted_step() {
         }
 
         @DoNotIntercept


### PR DESCRIPTION
Better late than never :wink: 
This PR changes JGiven's behavior with respect to methods that should not be intercepted (annotated with `@DoNotIntercept` or methods of `java.lang.Object`). These methods will now not trigger a change of the active stage and hence not trigger any `@AfterStage` methods.
I have thought about adding a new annotation to solve my issue #266, but in fact I don't see the use of those methods triggering any JGiven behavior.
This is pretty much the behavior I had expected from `@DoNotIntercept` anyway, to have absolutely no side effects within JGiven.
If I have missed a point here (I don't know the code base very well), let me know. But since all tests seemed to pass, I figured that there was no specific reason for the old behavior.

Resolves: #266