### PR TITLE
introduce DualScenarioTest

### DIFF
--- a/docs/getting_started.adoc
+++ b/docs/getting_started.adoc
@@ -15,6 +15,7 @@ include::{sourcedir}/MyShinyJGivenTest.java[tags=header]
 ----
 
 The `ScenarioTest` requires 3 type parameters. Each of these type parameters represents a stage of the Given-When-Then notation. Note that there is also the `SimpleScenarioTest` class that only requires a single type parameter. In that case, all your scenario steps are defined in a single class.
+For scenarios where you only want to differentiate between steps that modify state (setup in `given()`, changes in `when()`) and steps that assert state (`then()`) you can use the `DualScenarioTest` which takes two parameters: a combined `GivenWhen` stage and a single `Then` stage.
 
 
 

--- a/docs/junit5.adoc
+++ b/docs/junit5.adoc
@@ -63,8 +63,8 @@ public class JUnit5Test {
 }
 ----
 
-Alternatively, you can use one of the test base classes link:{javadocurl}/ScenarioTest.html[`ScenarioTest`] or
-link:{javadocurl}/SimpleScenarioTest.html[`SimpleScenarioTest`] that provide additional convenience methods
+Alternatively, you can use one of the test base classes link:{javadocurl}/ScenarioTest.html[`ScenarioTest`],
+link:{javadocurl}/SimpleScenarioTest.html[`SimpleScenarioTest`] or link:{javadocurl}/DualScenarioTest.html[`DualScenarioTest`] that provide additional convenience methods
 and allows you to specify stage classes by using type parameters:
 
 [source,java]

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/base/DualScenarioTestBase.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/base/DualScenarioTestBase.java
@@ -1,0 +1,26 @@
+package com.tngtech.jgiven.base;
+
+import com.google.common.reflect.TypeToken;
+import com.tngtech.jgiven.impl.Scenario;
+
+
+/**
+ * ScenarioTest that only takes two type parameters, where the first is used for combined
+ * GIVEN and WHEN and the second is used for THEN.
+ *
+ * This is useful for tests, where you often need to use WHEN steps also in GIVEN statements.
+ *
+ * This class is typically not directly used by end users,
+ * but instead test-framework-specific classes for JUnit or TestNG
+ */
+public abstract class DualScenarioTestBase<GIVEN_WHEN, THEN> extends ScenarioTestBase<GIVEN_WHEN,GIVEN_WHEN, THEN> {
+
+  @SuppressWarnings( { "serial", "unchecked" } )
+  protected Scenario<GIVEN_WHEN, GIVEN_WHEN, THEN> createScenario() {
+    Class<GIVEN_WHEN> givenWhenClass = (Class<GIVEN_WHEN>) new TypeToken<GIVEN_WHEN>( getClass() ) {}.getRawType();
+    Class<THEN> thenClass = (Class<THEN>) new TypeToken<THEN>( getClass() ) {}.getRawType();
+
+    return new Scenario<>(givenWhenClass, givenWhenClass, thenClass);
+  }
+
+}

--- a/jgiven-junit/src/main/java/com/tngtech/jgiven/junit/DualScenarioTest.java
+++ b/jgiven-junit/src/main/java/com/tngtech/jgiven/junit/DualScenarioTest.java
@@ -1,0 +1,20 @@
+package com.tngtech.jgiven.junit;
+
+import com.tngtech.jgiven.base.DualScenarioTestBase;
+import com.tngtech.jgiven.impl.Scenario;
+import org.junit.ClassRule;
+import org.junit.Rule;
+
+public class DualScenarioTest <GIVEN_WHEN, THEN> extends DualScenarioTestBase<GIVEN_WHEN, THEN> {
+
+  @ClassRule
+  public static final JGivenClassRule writerRule = new JGivenClassRule();
+
+  @Rule
+  public final JGivenMethodRule scenarioRule = new JGivenMethodRule( createScenario() );
+
+  @Override
+  public Scenario<GIVEN_WHEN, GIVEN_WHEN, THEN> getScenario() {
+    return (Scenario<GIVEN_WHEN, GIVEN_WHEN, THEN>) scenarioRule.getScenario();
+  }
+}

--- a/jgiven-junit/src/main/java/com/tngtech/jgiven/junit/DualScenarioTest.java
+++ b/jgiven-junit/src/main/java/com/tngtech/jgiven/junit/DualScenarioTest.java
@@ -14,6 +14,7 @@ public class DualScenarioTest <GIVEN_WHEN, THEN> extends DualScenarioTestBase<GI
   public final JGivenMethodRule scenarioRule = new JGivenMethodRule( createScenario() );
 
   @Override
+  @SuppressWarnings("unchecked")
   public Scenario<GIVEN_WHEN, GIVEN_WHEN, THEN> getScenario() {
     return (Scenario<GIVEN_WHEN, GIVEN_WHEN, THEN>) scenarioRule.getScenario();
   }

--- a/jgiven-junit/src/main/java/com/tngtech/jgiven/junit/SimpleScenarioTest.java
+++ b/jgiven-junit/src/main/java/com/tngtech/jgiven/junit/SimpleScenarioTest.java
@@ -14,6 +14,7 @@ public class SimpleScenarioTest<STEPS> extends SimpleScenarioTestBase<STEPS> {
     public final JGivenMethodRule scenarioRule = new JGivenMethodRule( createScenario() );
 
     @Override
+    @SuppressWarnings("unchecked")
     public Scenario<STEPS, STEPS, STEPS> getScenario() {
         return (Scenario<STEPS, STEPS, STEPS>) scenarioRule.getScenario();
     }

--- a/jgiven-junit5/src/main/java/com/tngtech/jgiven/junit5/DualScenarioTest.java
+++ b/jgiven-junit5/src/main/java/com/tngtech/jgiven/junit5/DualScenarioTest.java
@@ -1,0 +1,29 @@
+package com.tngtech.jgiven.junit5;
+
+import com.tngtech.jgiven.base.DualScenarioTestBase;
+import com.tngtech.jgiven.impl.Scenario;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+
+/**
+ * Convenience test base class for writing JGiven scenarios with JUnit 5.
+ * If you only have one stage class you can also use the {@link SimpleScenarioTest} class.
+ * If you don't want to inherit from any class you can just use the {@link JGivenExtension}
+ * directly.
+ *
+ * @param <GIVEN_WHEN> the combined GIVEN and WHEN stage
+ * @param <THEN> the THEN stage
+ *
+ * @see JGivenExtension
+ * @see SimpleScenarioTest
+ */
+@ExtendWith( JGivenExtension.class )
+public class DualScenarioTest<GIVEN_WHEN, THEN> extends DualScenarioTestBase<GIVEN_WHEN, THEN> {
+
+    private Scenario<GIVEN_WHEN,GIVEN_WHEN, THEN> scenario = createScenario();
+
+    @Override
+    public Scenario<GIVEN_WHEN, GIVEN_WHEN, THEN> getScenario() {
+        return scenario;
+    }
+}

--- a/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/DualSpringRuleScenarioTest.java
+++ b/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/DualSpringRuleScenarioTest.java
@@ -1,0 +1,32 @@
+package com.tngtech.jgiven.integration.spring;
+
+import com.tngtech.jgiven.impl.Scenario;
+import com.tngtech.jgiven.junit.JGivenClassRule;
+import com.tngtech.jgiven.junit.JGivenMethodRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+
+/**
+ * A variant of {@link SpringRuleScenarioTest} works with two
+ * stage type parameters instead of three.
+ *
+ * @param <GIVEN_WHEN> the stage class that contains the step definitions for given and when
+ * @param <THEN> the stage class that contains the step definitions for then
+ *
+ *
+ * @since 0.13.0
+ */
+public class DualSpringRuleScenarioTest<GIVEN_WHEN, THEN> extends
+    InternalDualSpringScenarioTest<GIVEN_WHEN,THEN> {
+
+    @ClassRule
+    public static final JGivenClassRule writerRule = new JGivenClassRule();
+
+    @Rule
+    public final JGivenMethodRule scenarioRule = new JGivenMethodRule( createScenario() );
+
+    @Override
+    public Scenario<GIVEN_WHEN, GIVEN_WHEN, THEN> getScenario() {
+        return (Scenario<GIVEN_WHEN, GIVEN_WHEN, THEN>) scenarioRule.getScenario();
+    }
+}

--- a/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/DualSpringScenarioTest.java
+++ b/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/DualSpringScenarioTest.java
@@ -1,0 +1,20 @@
+package com.tngtech.jgiven.integration.spring;
+
+import com.tngtech.jgiven.junit.DualScenarioTest;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+
+/**
+ * A variant of {@link SpringScenarioTest} works with two
+ * stage type parameters instead of three.
+ *
+ * @param <GIVEN_WHEN> the stage class that contains the step definitions for given and when
+ * @param <THEN> the stage class that contains the step definitions for then
+ */
+public class DualSpringScenarioTest<GIVEN_WHEN,THEN> extends DualScenarioTest<GIVEN_WHEN, THEN> implements BeanFactoryAware {
+
+    public void setBeanFactory( BeanFactory beanFactory ) {
+        getScenario().setStageCreator( beanFactory.getBean( SpringStageCreator.class ) );
+    }
+
+}

--- a/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/InternalDualSpringScenarioTest.java
+++ b/jgiven-spring/src/main/java/com/tngtech/jgiven/integration/spring/InternalDualSpringScenarioTest.java
@@ -1,0 +1,36 @@
+package com.tngtech.jgiven.integration.spring;
+
+import com.tngtech.jgiven.base.DualScenarioTestBase;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
+
+/**
+ * Internal class necessary in order to provide the correct ordering of the {@link org.junit.rules.MethodRule}s. Must be public because of
+ * {@link SpringMethodRule}s validations.
+ * It should not be used directly. Instead, use {@link SimpleSpringRuleScenarioTest}.
+ *
+ * @param <GIVEN_WHEN>
+ * @param <THEN>
+ *
+ * @since 0.13.0
+ */
+public abstract class InternalDualSpringScenarioTest<GIVEN_WHEN, THEN> extends
+    DualScenarioTestBase<GIVEN_WHEN, THEN> implements BeanFactoryAware {
+
+    @ClassRule
+    public static final SpringClassRule springClassRule = new SpringClassRule();
+
+    @Rule
+    public final SpringMethodRule springMethodRule = new SpringMethodRule();
+
+    InternalDualSpringScenarioTest() {
+    }
+
+    public void setBeanFactory(BeanFactory beanFactory) {
+        this.getScenario().setStageCreator(beanFactory.getBean( SpringStageCreator.class ));
+    }
+}

--- a/jgiven-testng/src/main/java/com/tngtech/jgiven/testng/DualScenarioTest.java
+++ b/jgiven-testng/src/main/java/com/tngtech/jgiven/testng/DualScenarioTest.java
@@ -1,0 +1,15 @@
+package com.tngtech.jgiven.testng;
+
+import com.tngtech.jgiven.base.DualScenarioTestBase;
+import com.tngtech.jgiven.impl.Scenario;
+import com.tngtech.jgiven.impl.ScenarioHolder;
+import org.testng.annotations.Listeners;
+
+@Listeners( ScenarioTestListener.class )
+public class DualScenarioTest<GIVEN_WHEN, THEN> extends DualScenarioTestBase<GIVEN_WHEN, THEN> {
+
+    @Override
+    public Scenario<GIVEN_WHEN, GIVEN_WHEN, THEN> getScenario() {
+        return (Scenario<GIVEN_WHEN, GIVEN_WHEN, THEN>) ScenarioHolder.get().getScenarioOfCurrentThread();
+    }
+}


### PR DESCRIPTION
see #388 

Motivation: keep steps for given and when in same stage so you can easily build tests that build on each other like 

```
given().doA();
when().doB();
then().assertState();
```

and

```
given().doA().and().doB();
when().doC();
then().assertState();
```

Naming things was the hard part, I came up with DualScenarioTest ... if you are generally fine with the idea, I will continue adding tests and docs.