### PR TITLE
introduce jgiven-kotlin

### DIFF
--- a/jgiven-kotlin/build.gradle.kts
+++ b/jgiven-kotlin/build.gradle.kts
@@ -1,0 +1,28 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+  kotlin("jvm") version "1.3.21"
+  id("org.jetbrains.kotlin.plugin.allopen") version "1.3.21"
+}
+
+dependencies {
+  api(project(":jgiven-core"))
+
+  implementation(kotlin("stdlib-jdk8"))
+
+  testImplementation(project(":jgiven-junit"))
+}
+
+allOpen {
+  annotation("com.tngtech.jgiven.kotlin.JGivenStage")
+}
+
+
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions {
+  jvmTarget = "1.8"
+}
+val compileTestKotlin: KotlinCompile by tasks
+compileTestKotlin.kotlinOptions {
+  jvmTarget = "1.8"
+}

--- a/jgiven-kotlin/src/main/kotlin/JGivenKotlin.kt
+++ b/jgiven-kotlin/src/main/kotlin/JGivenKotlin.kt
@@ -1,0 +1,23 @@
+package com.tngtech.jgiven.kotlin
+
+import com.tngtech.jgiven.Stage
+import com.tngtech.jgiven.base.ScenarioTestBase
+
+/**
+ * Annotation that can be used in a non spring kotlin project to mark stages and
+ * make use of the `all-open` compiler plugin.
+ */
+annotation class JGivenStage
+
+// extension attributes on testBase
+
+val <G : Stage<G>, W : Stage<W>, T : Stage<T>> ScenarioTestBase<G, W, T>.GIVEN: G get() = given()
+val <G : Stage<G>, W : Stage<W>, T : Stage<T>> ScenarioTestBase<G, W, T>.WHEN: W get() = `when`()
+val <G : Stage<G>, W : Stage<W>, T : Stage<T>> ScenarioTestBase<G, W, T>.THEN: T get() = then()
+
+// extension attributes on stage
+
+val <X : Stage<X>> Stage<X>.AND: X get() = and()
+val <X : Stage<X>> Stage<X>.WITH: X get() = with()
+val <X : Stage<X>> Stage<X>.BUT: X get() = but()
+val <X : Stage<X>> Stage<X>.SELF: X get() = self()!!

--- a/jgiven-kotlin/src/test/kotlin/JGivenKotlinExtensionTest.kt
+++ b/jgiven-kotlin/src/test/kotlin/JGivenKotlinExtensionTest.kt
@@ -1,0 +1,62 @@
+package com.tngtech.jgiven.kotlin
+
+import com.tngtech.jgiven.Stage
+import com.tngtech.jgiven.annotation.ExpectedScenarioState
+import com.tngtech.jgiven.annotation.ProvidedScenarioState
+import com.tngtech.jgiven.annotation.ScenarioState.Resolution.NAME
+import com.tngtech.jgiven.junit.ScenarioTest
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * Simple Test that just checks the sum of two numbers, displaying how the allopen plugin
+ * works together with JGivenStage.
+ *
+ * given(), when(), then(), ...  are replaced by extension attributes for increased readability.
+ */
+class JGivenKotlinExtensionTest : ScenarioTest<JGivenKotlinGiven, JGivenKotlinWhen, JGivenKotlinThen>() {
+
+  @Test
+  fun `add two numbers`() {
+    GIVEN
+        .number(5)
+
+    WHEN
+        .we_add_number(7)
+
+    THEN
+        .the_result_is(12)
+  }
+}
+
+
+@JGivenStage
+class JGivenKotlinGiven : Stage<JGivenKotlinGiven>() {
+
+  @ProvidedScenarioState private var firstNumber : Int = 0
+
+  fun number(number : Int) : JGivenKotlinGiven = SELF.apply { firstNumber = number }
+}
+
+@JGivenStage
+class JGivenKotlinWhen : Stage<JGivenKotlinWhen>() {
+
+  @ExpectedScenarioState private var firstNumber : Int = 0
+  @ProvidedScenarioState private var secondNumber : Int = 0
+
+  fun we_add_number(number: Int) = SELF.apply { secondNumber = number }
+
+}
+
+@JGivenStage
+class JGivenKotlinThen : Stage<JGivenKotlinThen>() {
+
+  @ProvidedScenarioState(resolution = NAME) private var firstNumber : Int = 0
+  @ProvidedScenarioState(resolution = NAME) private var secondNumber : Int = 0
+
+  fun the_result_is(expected: Int) = SELF.apply {
+    Assert.assertEquals(expected, firstNumber + secondNumber)
+  }
+
+}
+

--- a/jgiven-kotlin/src/test/resources/log4j.properties
+++ b/jgiven-kotlin/src/test/resources/log4j.properties
@@ -1,0 +1,4 @@
+log4j.rootLogger=ERROR, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,8 @@ include ':jgiven-core',
         ':jgiven-testng',
         ':jgiven-spring',
         ':jgiven-html-app',
-        ':jgiven-html5-report'
+        ':jgiven-html5-report',
+        ':jgiven-kotlin'
 
 def release = System.env.RELEASE == "true"
 def android = System.env.ANDROID == "true"


### PR DESCRIPTION
Kotlin is working just fine with jgiven, but in day to day usage, some problems occur. This module provides useful fixes and extensions:

* it contains a JGivenStage annotation that can be used to configure the kotlin "all-open" plugin, otherwise stage classes and all stage methods would have to be explicitly marked as open 
* "when" is a keyword in kotlin, so Stage.when() has to be written as Stage.`when`() ... I introduced extension properties for given()/when()/then()/... so a kotlin test can be written like:

```
class JGivenKotlinExtensionTest : ScenarioTest<JGivenKotlinGiven, JGivenKotlinWhen, JGivenKotlinThen>() {

  @Test
  fun `add two numbers`() {
    GIVEN
        .number(5)

    WHEN
        .we_add_number(7)

    THEN
        .the_result_is(12)
  }
}

```

What do you think?

Attention: this is just a kick-off PR, if you would integrate this into jgiven, we'd have to set up the dokka plugin for java doc generation.