### PR TITLE
Change exception handling for TestNG (#312)

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/StepInterceptorImpl.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/StepInterceptorImpl.java
@@ -43,6 +43,8 @@ public class StepInterceptorImpl implements StepInterceptor {
 
     private int maxStepDepth = INITIAL_MAX_STEP_DEPTH;
 
+    private InvocationMode defaultInvocationMode = InvocationMode.NORMAL;
+
     /**
      * Whether methods should be intercepted or not
      */
@@ -52,6 +54,11 @@ public class StepInterceptorImpl implements StepInterceptor {
      * Whether step methods are actually executed or just skipped
      */
     private boolean methodExecutionEnabled = true;
+
+    /**
+     * Whether all exceptions should be suppressed and not be rethrown
+     */
+    private boolean suppressExceptions = true;
 
     public StepInterceptorImpl(ScenarioExecutor scenarioExecutor, ScenarioListener listener, StageTransitionHandler stageTransitionHandler) {
         this.scenarioExecutor = scenarioExecutor;
@@ -191,7 +198,7 @@ public class StepInterceptorImpl implements StepInterceptor {
             return PENDING;
         }
 
-        return NORMAL;
+        return defaultInvocationMode;
     }
 
     public void enableMethodInterception(boolean b ) {
@@ -208,7 +215,15 @@ public class StepInterceptorImpl implements StepInterceptor {
         return previousMethodExecution;
     }
 
-    private void handleMethod( Object stageInstance, Method paramMethod, Object[] arguments, InvocationMode mode,
+    public void setSuppressExceptions(boolean b) {
+        suppressExceptions = b;
+    }
+
+    public void setDefaultInvocationMode(InvocationMode defaultInvocationMode) {
+        this.defaultInvocationMode = defaultInvocationMode;
+    }
+
+    private void handleMethod(Object stageInstance, Method paramMethod, Object[] arguments, InvocationMode mode,
                               boolean hasNestedSteps ) throws Throwable {
 
         List<NamedArgument> namedArguments = ParameterNameUtil.mapArgumentsWithParameterNames( paramMethod,
@@ -222,7 +237,12 @@ public class StepInterceptorImpl implements StepInterceptor {
         }
 
         listener.stepMethodFailed( t );
+
         scenarioExecutor.failed( t );
+
+        if (!suppressExceptions) {
+            throw t;
+        }
     }
 
     private void handleMethodFinished( long durationInNanos, boolean hasNestedSteps ) {

--- a/jgiven-testng/src/test/java/com/tngtech/jgiven/testng/PendingTest.java
+++ b/jgiven-testng/src/test/java/com/tngtech/jgiven/testng/PendingTest.java
@@ -1,0 +1,50 @@
+package com.tngtech.jgiven.testng;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.jgiven.annotation.Pending;
+import com.tngtech.jgiven.report.model.ExecutionStatus;
+import org.assertj.core.api.Assertions;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import com.tngtech.jgiven.annotation.Description;
+import com.tngtech.jgiven.report.model.ScenarioCaseModel;
+import com.tngtech.jgiven.report.model.StepStatus;
+
+@Description( "Pending annotation is handled correctly" )
+public class PendingTest extends SimpleScenarioTest<TestNgTest.TestSteps> {
+
+    @Test
+    @Pending
+    public void pending_annotation_should_catch_exceptions() {
+        given().something();
+        when().something_fails();
+        then().nothing_happens();
+
+        ScenarioCaseModel aCase = getScenario().getScenarioCaseModel();
+        assertThat( aCase.getExecutionStatus() ).isEqualTo( ExecutionStatus.SCENARIO_PENDING );
+    }
+
+    @Test
+    @Pending(executeSteps = true)
+    public void pending_annotation_should_catch_exceptions_when_executing_steps() {
+        given().something();
+        when().something_fails();
+        then().nothing_happens();
+
+        ScenarioCaseModel aCase = getScenario().getScenarioCaseModel();
+        assertThat( aCase.getExecutionStatus() ).isEqualTo( ExecutionStatus.SCENARIO_PENDING );
+    }
+
+    @Test
+    public void pending_annotation_on_failing_steps_should_catch_exceptions() {
+        given().something();
+        when().something_fails_with_pending_annotation();
+        then().nothing_happens();
+
+        ScenarioCaseModel aCase = getScenario().getScenarioCaseModel();
+        assertThat( aCase.getExecutionStatus() ).isEqualTo( ExecutionStatus.SOME_STEPS_PENDING );
+    }
+
+}

--- a/jgiven-testng/src/test/java/com/tngtech/jgiven/testng/RetryTest.java
+++ b/jgiven-testng/src/test/java/com/tngtech/jgiven/testng/RetryTest.java
@@ -1,0 +1,24 @@
+package com.tngtech.jgiven.testng;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+import org.testng.annotations.Test;
+
+@Test
+public class RetryTest extends SimpleScenarioTest<TestNgTest.TestSteps> {
+
+    int count = 0;
+
+    @Test(retryAnalyzer = MyAnalyzer.class)
+    public void failing_with_retry_test() {
+        when().something_should_$_fail(count++ == 0);
+    }
+
+    public static class MyAnalyzer implements IRetryAnalyzer {
+        int count = 0;
+        @Override
+        public boolean retry(ITestResult result) {
+            return count++ == 0;
+        }
+    }
+}

--- a/jgiven-testng/src/test/java/com/tngtech/jgiven/testng/TestNgTest.java
+++ b/jgiven-testng/src/test/java/com/tngtech/jgiven/testng/TestNgTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
+import com.tngtech.jgiven.annotation.Format;
+import com.tngtech.jgiven.annotation.Pending;
+import com.tngtech.jgiven.format.NotFormatter;
 import org.testng.annotations.Test;
 
 import com.tngtech.jgiven.Stage;
@@ -86,6 +89,18 @@ public class TestNgTest extends ScenarioTest<TestSteps, TestSteps, TestSteps> {
             throw new IllegalStateException( "Something failed" );
         }
 
+        @Pending
+        public TestSteps something_fails_with_pending_annotation() {
+            throw new IllegalStateException( "Something failed" );
+        }
+
+        public TestSteps something_should_$_fail(@Format(NotFormatter.class) boolean shouldFail) {
+            if (shouldFail) {
+                throw new IllegalStateException("Something failed");
+            }
+            return this;
+        }
+
         public TestSteps you_get_sugar_milk() {
             assertThat( result ).isEqualTo( "SugarMilk" );
             return this;
@@ -113,7 +128,9 @@ public class TestNgTest extends ScenarioTest<TestSteps, TestSteps, TestSteps> {
 
         public void mixed_with( String something ) {}
 
-        public void something() {}
+        public TestSteps something() {
+            return this;
+        }
 
         public void skipped_exception_is_thrown() {
             throw new org.testng.SkipException( "should be skipped" );

--- a/jgiven-tests/src/test/java/com/tngtech/jgiven/junit/JUnitExecutorTest.java
+++ b/jgiven-tests/src/test/java/com/tngtech/jgiven/junit/JUnitExecutorTest.java
@@ -38,4 +38,38 @@ public class JUnitExecutorTest extends JGivenScenarioTest<GivenScenarioTest<?>, 
         then().the_test_fails_with_message( "assertion failed in test step" );
     }
 
+    @Test
+    public void steps_following_failing_steps_are_reported_as_skipped() {
+        given().a_failing_test_with_$_steps( 3 )
+                .and().step_$_fails( 1 );
+        when().the_test_is_executed_with_JUnit();
+        then().step_$_is_reported_as_failed( 1 )
+                .and().step_$_is_reported_as_skipped( 2 )
+                .and().step_$_is_reported_as_skipped( 3 );
+    }
+
+    @Test
+    public void after_stage_methods_of_stages_following_failing_stages_are_ignored() {
+        given().a_failing_test_with_$_steps( 2 )
+                .and().the_test_has_$_failing_stages( 2 )
+                .and().stage_$_has_a_failing_after_stage_method( 2 )
+                .and().step_$_fails( 1 );
+        when().the_test_is_executed_with_JUnit();
+        then().the_test_fails()
+                .and().step_$_is_reported_as_failed( 1 )
+                .and().step_$_is_reported_as_skipped( 2 );
+    }
+
+    @Test
+    public void all_steps_of_stages_following_failing_stages_are_ignored() {
+        given().a_failing_test_with_$_steps( 2 )
+                .and().the_test_has_$_failing_stages( 2 )
+                .and().step_$_fails( 1 );
+        when().the_test_is_executed_with_JUnit();
+        then().the_test_fails()
+                .and().step_$_is_reported_as_failed( 1 )
+                .and().step_$_is_reported_as_skipped( 2 );
+    }
+
+
 }

--- a/jgiven-tests/src/test/java/com/tngtech/jgiven/testframework/TestFrameworkExecutionTest.java
+++ b/jgiven-tests/src/test/java/com/tngtech/jgiven/testframework/TestFrameworkExecutionTest.java
@@ -85,16 +85,6 @@ public class TestFrameworkExecutionTest extends JGivenScenarioTest<GivenScenario
     }
 
     @Test
-    public void steps_following_failing_steps_are_reported_as_skipped() {
-        given().a_failing_test_with_$_steps( 3 )
-            .and().step_$_fails( 1 );
-        when().the_test_is_executed_with( testFramework );
-        then().step_$_is_reported_as_failed( 1 )
-            .and().step_$_is_reported_as_skipped( 2 )
-            .and().step_$_is_reported_as_skipped( 3 );
-    }
-
-    @Test
     public void passing_steps_before_failing_steps_are_reported_as_passed() {
         given().a_failing_test_with_$_steps( 2 )
             .and().step_$_fails( 2 );
@@ -109,29 +99,6 @@ public class TestFrameworkExecutionTest extends JGivenScenarioTest<GivenScenario
         when().the_test_is_executed_with( testFramework );
         then().the_case_is_marked_as_failed()
             .and().an_error_message_is_stored_in_the_report();
-    }
-
-    @Test
-    public void all_steps_of_stages_following_failing_stages_are_ignored() {
-        given().a_failing_test_with_$_steps( 2 )
-            .and().the_test_has_$_failing_stages( 2 )
-            .and().step_$_fails( 1 );
-        when().the_test_is_executed_with( testFramework );
-        then().the_test_fails()
-            .and().step_$_is_reported_as_failed( 1 )
-            .and().step_$_is_reported_as_skipped( 2 );
-    }
-
-    @Test
-    public void after_stage_methods_of_stages_following_failing_stages_are_ignored() {
-        given().a_failing_test_with_$_steps( 2 )
-            .and().the_test_has_$_failing_stages( 2 )
-            .and().stage_$_has_a_failing_after_stage_method( 2 )
-            .and().step_$_fails( 1 );
-        when().the_test_is_executed_with( testFramework );
-        then().the_test_fails()
-            .and().step_$_is_reported_as_failed( 1 )
-            .and().step_$_is_reported_as_skipped( 2 );
     }
 
     @Test

--- a/jgiven-tests/src/test/java/com/tngtech/jgiven/testng/TestNgExecutor.java
+++ b/jgiven-tests/src/test/java/com/tngtech/jgiven/testng/TestNgExecutor.java
@@ -15,6 +15,8 @@ import com.tngtech.jgiven.report.model.ReportModel;
 import com.tngtech.jgiven.testframework.TestExecutionResult;
 import com.tngtech.jgiven.testframework.TestExecutor;
 
+import static com.tngtech.jgiven.testng.ScenarioTestListener.SCENARIO_ATTRIBUTE;
+
 public class TestNgExecutor extends TestExecutor {
 
     public static String methodName;
@@ -64,7 +66,7 @@ public class TestNgExecutor extends TestExecutor {
 
         private void setTestResult( ITestResult tr ) {
             testResults.add( tr );
-            reportModel = ((ScenarioBase)tr.getAttribute ("jgiven::scenario")).getModel();
+            reportModel = ((ScenarioBase)tr.getAttribute (SCENARIO_ATTRIBUTE)).getModel();
         }
     }
 


### PR DESCRIPTION
JGiven does not interact well with TestNG in case exceptions are thrown in step methods. Normally JGiven catches all exceptions to be able to report the following steps of a scenario and rethrows the exception at the end of a scenario. In JUnit this works as expected. In TestNG, however, the hook for JGiven comes too late to rethrow the exception. Thus TestNG always treats failing scenarios as success. This PR fixes this by not catching exceptions in steps anymore. The disadvantage of this is that the steps following a failed step cannot be reported anymore.