### PR TITLE
Dry-run support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ description = 'JGiven - BDD in plain Java'
 def jacocoEnabled = !JavaVersion.current().isJava11Compatible();
 
 wrapper {
-    gradleVersion = '5.6.2'
+    gradleVersion = '5.6.3'
     distributionType = Wrapper.DistributionType.ALL
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ description = 'JGiven - BDD in plain Java'
 def jacocoEnabled = !JavaVersion.current().isJava11Compatible();
 
 wrapper {
-    gradleVersion = '5.6.3'
+    gradleVersion = '5.6.4'
     distributionType = Wrapper.DistributionType.ALL
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.18.2
+version=0.18.3
 org.gradle.jvmargs=-Xmx1536M
 org.gradle.parallel=true
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jgiven-core/build.gradle
+++ b/jgiven-core/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     implementation "com.thoughtworks.paranamer:paranamer:$paranamerVersion"
     implementation "net.bytebuddy:byte-buddy:$bytebuddyVersion"
     implementation "org.fusesource.jansi:jansi:$jansiVersion"
+
+    testImplementation 'com.github.stefanbirkner:system-rules:1.2.0'
 }
 
 def generatedSourceDir = "generatedSrc/java"


### PR DESCRIPTION
Support for dry-run mode via a System property `jgiven.report.dry-run`=`true`
Feature to support #418 

@janschaefer could you give some feedback? 
We would like to use it to generate the narrative from the tests without executing the steps, it might be useful to generate it when the task is avoided because have been cached.

