### PR TITLE
Remove cause for does not adhere to convention warning

### DIFF
--- a/jgiven-core/src/test/java/com/tngtech/jgiven/GivenTestStep.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/GivenTestStep.java
@@ -19,14 +19,6 @@ public class GivenTestStep extends Stage<GivenTestStep> {
     @ScenarioState
     CurrentStep currentStep;
 
-    public void some_integer_value( int someIntValue ) {
-        value1 = someIntValue;
-    }
-
-    public void another_integer_value( int anotherValue ) {
-        value2 = anotherValue;
-    }
-
     public void an_integer_value_set_in_a_substep( int substepValue ) {
         givenTestComposedStep.some_integer_value_in_the_substep( substepValue );
     }

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/WhenTestStep.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/WhenTestStep.java
@@ -27,9 +27,7 @@ public class WhenTestStep extends Stage<WhenTestStep> {
         return self();
     }
 
-    public void an_exception_is_thrown() {
-        throw new RuntimeException();
-    }
+    public WhenTestStep an_exception_is_thrown() { throw new RuntimeException(); }
 
     @AfterStage
     void someAfterStageMethod() {

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/WhenTestStep.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/WhenTestStep.java
@@ -23,10 +23,6 @@ public class WhenTestStep extends Stage<WhenTestStep> {
         intResult = value1 * value2;
     }
 
-    public void multiply_with_two() {
-        intResult = someIntValue * 2;
-    }
-
     public WhenTestStep something_happens() {
         return self();
     }
@@ -38,14 +34,6 @@ public class WhenTestStep extends Stage<WhenTestStep> {
     @AfterStage
     void someAfterStageMethod() {
         afterStageCalled++;
-    }
-
-    public WhenTestStep one_parameter_is_used( String paramA ) {
-        return self();
-    }
-
-    public WhenTestStep another_parameter_is_used( String paramB ) {
-        return self();
     }
 
 }

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ScenarioModelBuilderTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ScenarioModelBuilderTest.java
@@ -466,9 +466,7 @@ public class ScenarioModelBuilderTest extends ScenarioTestBaseForTesting<GivenTe
     }
 
     static class FailingTestStage {
-        public void a_failing_test() {
-            throw new IllegalArgumentException( "test error" );
-        }
+        public FailingTestStage a_failing_test() { throw new IllegalArgumentException( "test error" ); }
     }
 
     static class ExtendedGivenTestStep extends AbstractStage {

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/FailingScenarioTest.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/FailingScenarioTest.java
@@ -19,8 +19,9 @@ public class FailingScenarioTest extends SimpleScenarioTest<FailingScenarioTest.
     }
 
     public static class Steps {
-        public void multi_line_error_message() {
+        public Steps multi_line_error_message() {
             assertThat(true).as("This\nmessage\nhas\nmultiple lines").isFalse();
+            return this;
         }
     }
 }

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/parameters/ParameterFormattingTest.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/parameters/ParameterFormattingTest.java
@@ -33,9 +33,7 @@ public class ParameterFormattingTest extends SimpleScenarioTest<ParameterFormatt
 
         public void the_power_light_$_on( @Format( value = BooleanFormatter.class, args = { "is", "is not" } ) boolean isOrIsNot ) {}
 
-        public void a_very_long_parameter_value( String x ) {
-
-        }
+        public void a_very_long_parameter_value( String x ) {}
 
         public TestSteps some_group_value( String grouping ) {
             return this;

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/StepsAreReportedTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/StepsAreReportedTest.java
@@ -147,13 +147,7 @@ public class StepsAreReportedTest extends ScenarioTest<TestSteps, TestSteps, Tes
         }
 
         @Pending
-        public void some_pending_step() {
-
-        }
-
-        public void a_step_fails() {
-            assertThat( true ).isFalse();
-        }
+        public void some_pending_step() { }
 
         @Hidden
         public void aHiddenStep() {}

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/StepsAreReportedTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/StepsAreReportedTest.java
@@ -147,7 +147,7 @@ public class StepsAreReportedTest extends ScenarioTest<TestSteps, TestSteps, Tes
         }
 
         @Pending
-        public void some_pending_step() { }
+        public TestSteps some_pending_step() {return self();}
 
         @Hidden
         public void aHiddenStep() {}

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/BeforeAfterTestStage.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/BeforeAfterTestStage.java
@@ -38,9 +38,7 @@ public class BeforeAfterTestStage {
 
     public void something() {}
 
-    public void someFailingStep() {
-        throw new IllegalStateException( "failed step" );
-    }
+    public BeforeAfterTestStage someFailingStep() {throw new IllegalStateException( "failed step" );}
 
     public class RuleForTesting {
         public int afterCalled;

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/GivenTestStep.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/GivenTestStep.java
@@ -68,10 +68,6 @@ public class GivenTestStep extends Stage<GivenTestStep> {
 
     }
 
-    public void some_step_fails( boolean fail ) {
-        assertThat( fail ).isFalse();
-    }
-
     public void a_step_with_a_table_parameter_and_primitive_array( @Table int... args ) {}
 
     @Table(columnTitles = { "custom" })
@@ -89,23 +85,17 @@ public class GivenTestStep extends Stage<GivenTestStep> {
         return self();
     }
 
-    public void another_quoted_string_value( @Quoted String anotherQuotedStringValue ) {
-
-    }
+    public void another_quoted_string_value( @Quoted String anotherQuotedStringValue ) { }
 
     public static class TableClass {
         public String value;
     }
 
-    public void some_data_table( @Table TableClass... param ) {
-
-    }
+    public void some_data_table( @Table TableClass... param ) { }
 
     public static class TestTableEntry {
         int some_field = 1;
     }
-
-    public void a_step_with_a_table_parameter( @Table TestTableEntry... args ) {}
 
     public static class CoffeePrice {
         String name;

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/ThenTestStep.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/ThenTestStep.java
@@ -15,15 +15,9 @@ public class ThenTestStep extends Stage<ThenTestStep> {
         assertThat( intResult > 0 ).isEqualTo( b );
     }
 
-    public void sms_and_emails_exist() {}
-
     public void the_result_is( int i ) {
         assertThat( intResult ).isEqualTo( i );
     }
 
     public void something() {}
-
-    public void something_is_allowed( boolean isAllowed ) {
-
-    }
 }

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/WhenTestStep.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/test/WhenTestStep.java
@@ -28,10 +28,6 @@ public class WhenTestStep extends Stage<WhenTestStep> {
 
     public void something() {}
 
-    public void some_assertion_fails() {
-        assertThat( true ).isFalse();
-    }
-
     public void some_assumption_fails() {
         Assume.assumeTrue( false );
     }

--- a/jgiven-tests/src/test/java/com/tngtech/jgiven/report/WhenReportGenerator.java
+++ b/jgiven-tests/src/test/java/com/tngtech/jgiven/report/WhenReportGenerator.java
@@ -59,10 +59,6 @@ public class WhenReportGenerator<SELF extends WhenReportGenerator<?>> extends St
         html5ReportConfig.setTargetDir( targetReportDir );
     }
 
-    public void the_report_generator_is_executed() {
-        the_report_generator_is_executed_with_format( Format.HTML5 );
-    }
-
     public SELF the_asciidoc_reporter_is_executed() {
         return the_report_generator_is_executed_with_format( Format.ASCIIDOC );
     }

--- a/jgiven-tests/src/test/java/com/tngtech/jgiven/report/text/ThenPlainTextOutput.java
+++ b/jgiven-tests/src/test/java/com/tngtech/jgiven/report/text/ThenPlainTextOutput.java
@@ -17,7 +17,4 @@ public class ThenPlainTextOutput extends Stage<ThenPlainTextOutput> {
         Assertions.assertThat( plainTextOutput.replace( System.getProperty("line.separator"), "\n" ) ).contains(line);
         return this;
     }
-
-    public void the_data_table_has_one_line_for_the_arguments_of_each_case() {}
-
 }


### PR DESCRIPTION
Tiny beauty PR. 
I removed some methods that were unused and added a return value to methods that would spawn a warning about having no return value in the logs.