### PR TITLE
Introducing "Syntactic Sugar" and "Navigable Stages"

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/BackStep.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/BackStep.java
@@ -1,0 +1,14 @@
+package com.tngtech.jgiven.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention( RetentionPolicy.RUNTIME )
+@Target( { ElementType.METHOD } )
+public @interface BackStep {
+
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/RootStep.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/RootStep.java
@@ -1,0 +1,14 @@
+package com.tngtech.jgiven.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention( RetentionPolicy.RUNTIME )
+@Target( { ElementType.METHOD } )
+public @interface RootStep {
+
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/SyntacticSugar.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/SyntacticSugar.java
@@ -1,0 +1,14 @@
+package com.tngtech.jgiven.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention( RetentionPolicy.RUNTIME )
+@Target( { ElementType.METHOD } )
+public @interface SyntacticSugar {
+
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/NavigableStage.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/NavigableStage.java
@@ -1,0 +1,28 @@
+package com.tngtech.jgiven.impl;
+
+import com.tngtech.jgiven.Stage;
+
+public abstract class NavigableStage<ROOT, BACK, SELF extends NavigableStage<ROOT, BACK, SELF>> extends Stage<SELF> {
+
+    private ROOT root;
+    private BACK back;
+
+    SELF root( ROOT root ) {
+        this.root = root;
+        return self();
+    }
+
+    protected ROOT root() {
+        return root;
+    }
+
+    SELF back( BACK back ) {
+        this.back = back;
+        return self();
+    }
+
+    protected BACK back() {
+        return back;
+    }
+
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/NavigableStageCreator.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/NavigableStageCreator.java
@@ -1,0 +1,16 @@
+package com.tngtech.jgiven.impl;
+
+public class NavigableStageCreator {
+
+    private final ScenarioExecutor scenarioExecutor;
+
+    NavigableStageCreator( ScenarioExecutor scenarioExecutor ) {
+        this.scenarioExecutor = scenarioExecutor;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <STAGE extends NavigableStage<ROOT, BACK, STAGE>, ROOT, BACK> STAGE nestedStage( STAGE prototype, ROOT root, BACK back ) {
+        return (STAGE) scenarioExecutor.addNavigableStage( prototype.getClass() ).root( root ).back( back );
+    }
+
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioExecutor.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioExecutor.java
@@ -1,6 +1,5 @@
 package com.tngtech.jgiven.impl;
 
-import com.google.common.collect.Maps;
 import com.tngtech.jgiven.CurrentScenario;
 import com.tngtech.jgiven.CurrentStep;
 import com.tngtech.jgiven.annotation.AfterScenario;
@@ -99,6 +98,7 @@ public class ScenarioExecutor {
         injector.injectValueByType( ScenarioExecutor.class, this );
         injector.injectValueByType( CurrentStep.class, new StepAccessImpl() );
         injector.injectValueByType( CurrentScenario.class, new ScenarioAccessImpl() );
+        injector.injectValueByType( NavigableStageCreator.class, new NavigableStageCreator( this ) );
     }
 
     protected static class StageState {
@@ -219,6 +219,13 @@ public class ScenarioExecutor {
             updateScenarioState( parentStage );
         }
 
+    }
+
+    public <T extends NavigableStage> T addNavigableStage( Class<T> stageClass ) {
+        stages.remove( stageClass );
+        T stage = addStage( stageClass );
+        getStageState( currentTopLevelStage ).currentChildStage = stage;
+        return stage;
     }
 
     @SuppressWarnings( "unchecked" )

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/NoOpScenarioListener.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/NoOpScenarioListener.java
@@ -26,6 +26,9 @@ public class NoOpScenarioListener implements ScenarioListener {
     public void introWordAdded( String introWord ) {}
 
     @Override
+    public void syntacticSugarAdded( String syntacticSugar ) {}
+
+    @Override
     public void stepCommentUpdated( String comment ) {}
 
     @Override

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/ScenarioListener.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/intercept/ScenarioListener.java
@@ -20,6 +20,8 @@ public interface ScenarioListener {
 
     void introWordAdded( String introWord );
 
+    void syntacticSugarAdded( String syntacticSugar );
+
     void stepCommentUpdated(String comment );
 
     void stepMethodFailed( Throwable t );

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/util/PrintWriterUtil.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/util/PrintWriterUtil.java
@@ -9,7 +9,12 @@ import com.tngtech.jgiven.config.ConfigValue;
 public class PrintWriterUtil {
     public static PrintWriter getPrintWriter( File file ) {
         try {
-            return new PrintWriter( file, Charsets.UTF_8.name() );
+            return new PrintWriter( file, Charsets.UTF_8.name() ) {
+                @Override
+                public void println() {
+                    write("\n");
+                }
+            };
         } catch( Exception e ) {
             throw Throwables.propagate( e );
         }

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/MovieFixture.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/MovieFixture.java
@@ -1,0 +1,114 @@
+package com.tngtech.jgiven.examples.movies;
+
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.annotation.SyntacticSugar;
+import com.tngtech.jgiven.examples.movies.model.Actor;
+import com.tngtech.jgiven.examples.movies.model.Movie;
+import com.tngtech.jgiven.examples.movies.stages.GivenMovie;
+import com.tngtech.jgiven.examples.movies.stages.MyNavigableStage;
+import com.tngtech.jgiven.examples.movies.stages.ThenMovie;
+import com.tngtech.jgiven.impl.NavigableStageCreator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MovieFixture {
+
+    public static class Given
+    extends MyNavigableStage.Top<Given> {
+
+        @ProvidedScenarioState
+        private NavigableStageCreator navigableStageCreator;
+
+        @ProvidedScenarioState
+        private List<Movie> movies = new ArrayList<>();
+
+        @ProvidedScenarioState
+        private List<Actor> actors = new ArrayList<>();
+
+        public GivenMovie<Given, Given> movie() {
+            Movie movie = new Movie();
+            movies.add(movie);
+
+            return navigableStageCreator.nestedStage( new GivenMovie<>(), this, this )
+            .withSubject(movie);
+        }
+
+        public Given $_movies( int count ) {
+            for ( int i = 0; i < count; i++ ) {
+                movie()
+                .title( "Movie: " + i );
+            }
+
+            return self();
+        }
+    }
+
+    public static class When
+    extends MyNavigableStage.Top<When> {
+
+    }
+
+    public static class Then
+    extends MyNavigableStage.Top<Then> {
+
+        @ExpectedScenarioState
+        private NavigableStageCreator navigableStageCreator;
+
+        @ExpectedScenarioState
+        private List<Movie> movies;
+
+        @ExpectedScenarioState
+        private List<Actor> actors = new ArrayList<>();
+
+        public Then $_movies( int count ) {
+            assertThat( movies ).hasSize( count );
+            return this;
+        }
+
+        @SyntacticSugar
+        public ThenMovie<Then, Then> first_movie() {
+            return navigableStageCreator.nestedStage( new ThenMovie<>(), this, this )
+            .withSubject( movies.get(0) );
+        }
+
+        @SyntacticSugar
+        public ThenMovie<Then, Then> second_movie() {
+            return navigableStageCreator.nestedStage( new ThenMovie<>(), this, this )
+            .withSubject( movies.get(1) );
+        }
+
+        @SyntacticSugar
+        public ThenMovie<Then, Then> third_movie() {
+            return navigableStageCreator.nestedStage( new ThenMovie<>(), this, this )
+            .withSubject( movies.get(2) );
+        }
+
+        public Then $_unrated_movies( int count ) {
+            assertThat(
+                movies.stream()
+                .filter( movie -> isNull( movie.rating() ) )
+                .count()
+            ).isEqualTo( count );
+
+            return self();
+        }
+
+        public Then $_unique_actors( int count ) {
+            assertThat(
+                actors.stream()
+                .map( Actor::name )
+                .collect( toSet() )
+            ).hasSize( count );
+
+            return self();
+        }
+
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/MovieTest.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/MovieTest.java
@@ -1,0 +1,49 @@
+package com.tngtech.jgiven.examples.movies;
+
+import com.tngtech.jgiven.junit.ScenarioTest;
+import org.junit.Test;
+
+public class MovieTest
+extends ScenarioTest<MovieFixture.Given, MovieFixture.When, MovieFixture.Then> {
+
+    @Test
+    public void movie_test() {
+
+        given() .a() .movie()
+            .with() .the() .title( "Die Hard" )
+            .and() .the() .rating( "18" )
+            .and() .an() .actor()
+                .with() .the() .name( "Bruce Willis" )
+
+        .also() .a() .movie()
+            .with() .the() .title( "Die Hard 2" )
+            .and() .an() .actor()
+                .with() .the() .name( "Bruce Willis" )
+
+        .also() .a() .movie()
+            .with() .the() .title( "The Terminator" )
+            .and() .an() .actor()
+                .with() .the() .name( "Arnold Schwarzenegger" );
+
+        then() .there() .are() .$_movies( 3 )
+            .the() .first_movie()
+                .has() .the() .title( "Die Hard" )
+            .and_the() .second_movie()
+                .has() .the() .title( "Die Hard 2" )
+            .and_the() .third_movie()
+                .has() .the() .title( "The Terminator" )
+            .and_there() .are() .$_unrated_movies( 2 )
+            .and() .there() .are() .$_unique_actors( 2 );
+
+    }
+
+    @Test
+    public void multiple_movies() {
+
+        given() .$_movies( 5 );
+
+        then() .there() .are() .$_movies( 5 );
+
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/model/Actor.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/model/Actor.java
@@ -1,0 +1,16 @@
+package com.tngtech.jgiven.examples.movies.model;
+
+public class Actor {
+
+    private String name;
+
+    public String name() {
+        return name;
+    }
+
+    public Actor name( String name ) {
+        this.name = name;
+        return this;
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/model/Movie.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/model/Movie.java
@@ -1,0 +1,26 @@
+package com.tngtech.jgiven.examples.movies.model;
+
+public class Movie {
+
+    private String title;
+    private String rating;
+
+    public String title() {
+        return title;
+    }
+
+    public Movie title( String title ) {
+        this.title = title;
+        return this;
+    }
+
+    public String rating() {
+        return rating;
+    }
+
+    public Movie rating( String rating ) {
+        this.rating = rating;
+        return this;
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/stages/GivenActor.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/stages/GivenActor.java
@@ -1,0 +1,29 @@
+package com.tngtech.jgiven.examples.movies.stages;
+
+import com.tngtech.jgiven.annotation.AfterStage;
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.Quoted;
+import com.tngtech.jgiven.examples.movies.model.Actor;
+import com.tngtech.jgiven.impl.NavigableStage;
+
+import java.util.List;
+
+public class GivenActor<ROOT, BACK>
+extends MyNavigableStage<ROOT, BACK, GivenActor<ROOT, BACK>> {
+
+    @ExpectedScenarioState
+    private List<Actor> actors;
+
+    private Actor subject = new Actor();
+
+    @AfterStage
+    private void afterStage() {
+        actors.add(subject);
+    }
+
+    public GivenActor<ROOT, BACK> name( @Quoted String name ) {
+        subject.name( name );
+        return self();
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/stages/GivenMovie.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/stages/GivenMovie.java
@@ -1,0 +1,35 @@
+package com.tngtech.jgiven.examples.movies.stages;
+
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.annotation.Quoted;
+import com.tngtech.jgiven.examples.movies.model.Movie;
+import com.tngtech.jgiven.impl.NavigableStageCreator;
+
+public class GivenMovie<ROOT, BACK>
+extends MyNavigableStage<ROOT, BACK, GivenMovie<ROOT, BACK>> {
+
+    @ProvidedScenarioState
+    private NavigableStageCreator navigableStageCreator;
+
+    private Movie subject;
+
+    public GivenMovie<ROOT, BACK> withSubject( Movie subject) {
+        this.subject = subject;
+        return self();
+    }
+
+    public GivenMovie<ROOT, BACK> title( @Quoted String title ) {
+        subject.title( title );
+        return self();
+    }
+
+    public GivenMovie<ROOT, BACK> rating( @Quoted String rating ) {
+        subject.rating( rating );
+        return self();
+    }
+
+    public GivenActor<ROOT, GivenMovie<ROOT, BACK>> actor() {
+        return navigableStageCreator.nestedStage( new GivenActor<>(), root(), this );
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/stages/MyNavigableStage.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/stages/MyNavigableStage.java
@@ -1,0 +1,75 @@
+package com.tngtech.jgiven.examples.movies.stages;
+
+import com.tngtech.jgiven.annotation.BackStep;
+import com.tngtech.jgiven.annotation.RootStep;
+import com.tngtech.jgiven.annotation.SyntacticSugar;
+import com.tngtech.jgiven.impl.NavigableStage;
+
+public class MyNavigableStage<ROOT, BACK, SELF extends MyNavigableStage<ROOT, BACK, SELF>> extends NavigableStage<ROOT, BACK, SELF> {
+
+    public static class Top<SELF extends Top<SELF>> extends MyNavigableStage<SELF, SELF, SELF> {
+
+    }
+
+    @RootStep
+    public ROOT also() { return root(); }
+
+    @BackStep
+    public BACK and_a() { return back(); }
+
+    @BackStep
+    public BACK and_the() {
+        return back();
+    }
+
+    @BackStep
+    public BACK and_there() {
+        return back();
+    }
+
+    @SyntacticSugar
+    public SELF a() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF an() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF and() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF are() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF has() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF the() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF there() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF with() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF but() {
+        return self();
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/stages/ThenMovie.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/movies/stages/ThenMovie.java
@@ -1,0 +1,23 @@
+package com.tngtech.jgiven.examples.movies.stages;
+
+import com.tngtech.jgiven.annotation.Quoted;
+import com.tngtech.jgiven.examples.movies.model.Movie;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThenMovie<ROOT, BACK>
+extends MyNavigableStage<ROOT, BACK, ThenMovie<ROOT, BACK>> {
+
+    private Movie subject;
+
+    public ThenMovie<ROOT, BACK> withSubject( Movie subject ) {
+        this.subject = subject;
+        return self();
+    }
+
+    public ThenMovie<ROOT, BACK> title( @Quoted String title ) {
+        assertThat( subject.title() ).isEqualTo( title );
+        return self();
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/pancakes/test/SpringPanCakeScenarioWithNavigationTest.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/pancakes/test/SpringPanCakeScenarioWithNavigationTest.java
@@ -1,0 +1,31 @@
+package com.tngtech.jgiven.examples.pancakes.test;
+
+import com.tngtech.jgiven.examples.pancakes.test.fixtures.PanCakeScenarioFixture.Given;
+import com.tngtech.jgiven.examples.pancakes.test.fixtures.PanCakeScenarioFixture.Then;
+import com.tngtech.jgiven.examples.pancakes.test.fixtures.PanCakeScenarioFixture.When;
+import com.tngtech.jgiven.integration.spring.SpringScenarioTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith( SpringJUnit4ClassRunner.class )
+@ContextConfiguration( classes = TestSpringConfig.class )
+public class SpringPanCakeScenarioWithNavigationTest extends SpringScenarioTest<Given, When, Then> {
+
+    @Test
+    public void a_pancake_can_be_fried_out_of_an_egg_milk_and_flour() {
+
+        given() .ingredients()
+            .consisting() .of() .an() .egg()
+            .some() .milk()
+            .and() .the() .ingredient( "flour" );
+
+        when() .the() .cook()
+            .mangles_everything_to_a_dough()
+            .and() .then() .fries_the_dough_in_a_pan();
+
+        then() .the() .resulting_meal_is_a_pan_cake();
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/pancakes/test/fixtures/PanCakeScenarioFixture.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/pancakes/test/fixtures/PanCakeScenarioFixture.java
@@ -1,0 +1,59 @@
+package com.tngtech.jgiven.examples.pancakes.test.fixtures;
+
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.examples.pancakes.test.stages.GivenTheIngredients;
+import com.tngtech.jgiven.examples.pancakes.test.stages.MyNavigableStage;
+import com.tngtech.jgiven.examples.pancakes.test.stages.WhenTheCook;
+import com.tngtech.jgiven.impl.NavigableStageCreator;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PanCakeScenarioFixture {
+
+    @JGivenStage
+    public static class Given extends MyNavigableStage.Top<Given> {
+
+        @ExpectedScenarioState
+        NavigableStageCreator navigableStageCreator;
+
+        @ProvidedScenarioState
+        private List<String> ingredients = new ArrayList<>();
+
+        public GivenTheIngredients<Given, Given> ingredients() {
+            return navigableStageCreator.nestedStage( new GivenTheIngredients<>(), this, this)
+            .withSubject(ingredients);
+        }
+
+    }
+
+    @JGivenStage
+    public static class When extends MyNavigableStage.Top<When> {
+
+        @ExpectedScenarioState
+        NavigableStageCreator navigableStageCreator;
+
+        public WhenTheCook<When, When> cook() {
+            return navigableStageCreator.nestedStage(new WhenTheCook<>(), this, this);
+        }
+
+    }
+
+    @JGivenStage
+    public static class Then extends MyNavigableStage.Top<Then> {
+
+        @ExpectedScenarioState
+        private String meal;
+
+        public Then resulting_meal_is_a_pan_cake() {
+            assertThat( meal ).isEqualTo( "pancake" );
+            return self();
+        }
+
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/pancakes/test/stages/GivenTheIngredients.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/pancakes/test/stages/GivenTheIngredients.java
@@ -1,0 +1,41 @@
+package com.tngtech.jgiven.examples.pancakes.test.stages;
+
+import com.tngtech.jgiven.annotation.SyntacticSugar;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+
+import java.util.List;
+
+@JGivenStage
+public class GivenTheIngredients<ROOT, BACK> extends MyNavigableStage<ROOT, BACK, GivenTheIngredients<ROOT, BACK>> {
+
+    private List<String> subject;
+
+    public GivenTheIngredients<ROOT, BACK> withSubject(List<String> subject ) {
+        this.subject = subject;
+        return self();
+    }
+
+    public GivenTheIngredients<ROOT, BACK> egg() {
+        return ingredient( "egg" );
+    }
+
+    public GivenTheIngredients<ROOT, BACK> milk() {
+        return ingredient( "milk" );
+    }
+
+    public GivenTheIngredients<ROOT, BACK> ingredient(String ingredient) {
+        subject.add( ingredient );
+        return self();
+    }
+
+    @SyntacticSugar
+    public GivenTheIngredients<ROOT, BACK> consisting() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public GivenTheIngredients<ROOT, BACK> some() {
+        return self();
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/pancakes/test/stages/MyNavigableStage.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/pancakes/test/stages/MyNavigableStage.java
@@ -1,0 +1,75 @@
+package com.tngtech.jgiven.examples.pancakes.test.stages;
+
+import com.tngtech.jgiven.annotation.BackStep;
+import com.tngtech.jgiven.annotation.RootStep;
+import com.tngtech.jgiven.annotation.SyntacticSugar;
+import com.tngtech.jgiven.impl.NavigableStage;
+
+public abstract class MyNavigableStage<ROOT, BACK, SELF extends MyNavigableStage<ROOT, BACK, SELF>> extends NavigableStage<ROOT, BACK, SELF> {
+
+    public static class Top<SELF extends Top<SELF>> extends MyNavigableStage<SELF, SELF, SELF> {
+
+    }
+
+    @RootStep
+    public ROOT also() { return root(); }
+
+    @BackStep
+    public BACK and_a() { return back(); }
+
+    @BackStep
+    public BACK and_the() {
+        return back();
+    }
+
+    @SyntacticSugar
+    public SELF a() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF an() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF and() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF are() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF has() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF of() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF the() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF there() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF with() {
+        return self();
+    }
+
+    @SyntacticSugar
+    public SELF but() {
+        return self();
+    }
+
+}

--- a/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/pancakes/test/stages/WhenTheCook.java
+++ b/jgiven-examples/src/test/java/com/tngtech/jgiven/examples/pancakes/test/stages/WhenTheCook.java
@@ -1,0 +1,48 @@
+package com.tngtech.jgiven.examples.pancakes.test.stages;
+
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import com.tngtech.jgiven.examples.pancakes.app.Cook;
+import com.tngtech.jgiven.impl.NavigableStage;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JGivenStage
+public class WhenTheCook<ROOT, BACK> extends NavigableStage<ROOT, BACK, WhenTheCook<ROOT, BACK>> {
+
+    @Autowired
+    private Cook cook;
+
+    @ExpectedScenarioState
+    private List<String> ingredients;
+
+    @ProvidedScenarioState
+    Set<String> dough;
+
+    @ProvidedScenarioState
+    String meal;
+
+    public WhenTheCook<ROOT, BACK> mangles_everything_to_a_dough() {
+        assertThat( cook ).isNotNull();
+        assertThat( ingredients ).isNotNull();
+
+        dough = cook.makeADough( ingredients );
+
+        return self();
+    }
+
+    public WhenTheCook<ROOT, BACK> fries_the_dough_in_a_pan() {
+        assertThat( cook ).isNotNull();
+        assertThat( dough ).isNotNull();
+
+        meal = cook.fryDoughInAPan( dough );
+
+        return self();
+    }
+
+}


### PR DESCRIPTION
Hello to the JGiven community. First and foremost I’d like to give you my appreciation for the project. I’ve been 
using it for approximately 3 years now. It’s completely transformed the way we write tests in my organisation.

I thought I’d take the time to present some of the in-house enhancements we have made to the project, which supports 
the way we like to write our tests.

Please consider this pull request as a means of starting a conversation about the concepts. If you like the ideas I am 
more than happy to provide comprehensive documentation on the features, add further tests and to incorporate changes 
based on your advice where I may not have done something the “JGiven Way”.

### Concept 1 – ‘Syntactic Sugar’

A new `@SyntacticSugar` annotation has been added which can be used much like the current `@IntroWord` annotation. 
The idea is that you can use syntactic sugar to create a reusable vocabulary to improve the readability of your tests
whilst at the same time keeping your stage methods clean and concise.

For example take the following Syntactic Sugar:

```java
@SyntacticSugar public SELF an() { return self(); }
@SyntacticSugar public SELF of() { return self(); }
@SyntacticSugar public SELF the() { return self(); }
@SyntacticSugar public SELF consisting() { return self(); }
@SyntacticSugar public SELF some() { return self(); }
```

You could rewrite the given in the pancake test example as follows:

```java
given() .ingredients()
    .consisting() .of() .an() .egg()
    .some() .milk()
    .and() .the() .ingredient( "flour" );
```

Which results in a test report as follows:

```
   Given ingredients
           consisting of an egg
           some milk
           and the ingredient flour
```

Syntactic sugar is not capitalised and can be chained together to create beautifully fluent tests.

You may also add `@SyntacticSugar` to stage methods which will prevent line breaks in reports, for example:

```java
@SyntacticSugar
public SELF egg() {
    return ingredient( "egg" );
}

@SyntacticSugar
public SELF milk() {
    return ingredient( "milk" );
}

public SELF ingredient(String ingredient) {
    subject.add( ingredient );
    return self();
}
```

Running the same test would now result in the following report:

```
   Given ingredients
           consisting of an egg some milk and the ingredient flour
```

### Concept 2 – Navigable Stages

Navigable stages allow you to build concise, single-purpose, reusable “building blocks” for writing your tests. 
With a configured vocabulary you can navigate through a tree of stages fluently within your test case. A navigable 
stage holds on to 2 key reference points; a “ROOT” and a “BACK”. A ROOT is the top of the stage tree, i.e. your 
“Top-Level” given whereas a BACK is used to refer to the parent of a navigable stage. With your choice of vocabulary 
you may navigate to your root or back markers at any point.

Given the following vocabulary:

```java
@BackStep public BACK and_an() { return back(); }
@SyntacticSugar public SELF a() { return self(); }
@SyntacticSugar public SELF an() { return self(); }
@SyntacticSugar public SELF with() { return self(); }
@SyntacticSugar public SELF the() { return self(); }
```

You could write the following:

```java
given() .a() .movie()
    .with() .the() .title( "The Terminator" )
    .and() .an() .actor()
        .with() .the() .name( "Arnold Schwarzenegger" )
    .and_an() .actor()
        .with() .the() .name( "Linda Hamilton" );
```

Here we have 3 different stage classes, a top level `Given`, a `GivenMovie` stage which is created when you call 
`movie()` on the top level `Given` and a `GivenActor` stage which is created when you call `actor()` on a `GivenMovie` 
stage.

You can see from the example of above that the use of the `@BackStep` `and_an()` navigates us back from the 
`GivenActor` class to its parent `GivenMovie` instance allowing us to then create a second actor under the movie.

The generated report follows the indentation I’ve used above:

```
   Given a movie
           with the title "The Terminator"
           and an actor
             with the name "Arnold Schwarzenegger"
           and an actor
             with the name "Linda Hamilton"
```

Finally navigable stages also allow you to jump back to the top of the tree.

For example, given the following vocabulary:

```java
@RootStep public ROOT also() { return root(); }
@BackStep public BACK and_an() { return back(); }
@SyntacticSugar public SELF a() { return self(); }
@SyntacticSugar public SELF an() { return self(); }
@SyntacticSugar public SELF with() { return self(); }
@SyntacticSugar public SELF the() { return self(); }
```

You can write the following:

```java
given() .a() .movie()
    .with() .the() .title( "Die Hard" )
    .and() .an() .actor()
        .with() .the() .name( "Bruce Willis" )

.also() .a() .movie()
    .with() .the() .title( "Die Hard 2" )
    .and() .an() .actor()
        .with() .the() .name( "Bruce Willis" )

.also() .a() .movie()
    .with() .the() .title( "The Terminator" )
    .and() .an() .actor()
        .with() .the() .name( "Arnold Schwarzenegger" )
    .and_an() .actor()
        .with() .the() .name( "Linda Hamilton" );
```

Wherever you are in the tree of stages `also()` will take you back to the top level given where you can once again 
start created nested stages.

Creating a navigable stage is simple. Extend the `NavigableStage` abstract class, or an extension of it with your 
own vocabulary. 

For example:

```java
public class GivenActor<ROOT, BACK>
extends NavigableStage<ROOT, BACK, GivenActor<ROOT, BACK>> {

    . . .

}
```

When you require a new instance of a navigable stage use the `NavigableStageCreator` injected with 
`@ProvidedScenarioState` as follows:

```java
@ProvidedScenarioState
private NavigableStageCreator navigableStageCreator;

public GivenActor<ROOT, GivenMovie<ROOT, BACK>> actor() {
    return navigableStageCreator.nestedStage( new GivenActor<>(), root(), this );
}
```

Where the 3 arguments passed to nestedStage are:
1.	A new instance of the required child stage
2.	The new child stage’s `ROOT` reference
3.	The new child stage’s `BACK` reference


Please take a look at the pull request which shows my implementation supporting all of the above. 
I’ve also added a couple of tests that demonstrate the concepts in action.

We have found that these new capabilities and of course discipline in making sure that a test only details information 
pertinent to what’s being tested has provided us with exceptional suites of tests. We write everything from low-level 
unit tests to full integration tests the same way.

I would love to see this concepts built into JGiven and used by the masses. If you think we’re onto something with
these ideas it would be a privilege to work alongside you to refine the PR to the stage that you’d be happy to accept it.
