### PR TITLE
replace custom `npm` execution by Gradle Node plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,8 @@ plugins {
     id 'org.asciidoctor.jvm.convert' version '2.3.0'
     id 'io.codearte.nexus-staging' version '0.21.1'
     id 'com.github.ben-manes.versions' version '0.27.0'
-    id "org.sonarqube" version "2.8" apply false
+    id 'org.sonarqube' version '2.8' apply false
+    id 'com.github.node-gradle.node' version '2.2.4' apply false
 }
 
 apply plugin: 'project-report'

--- a/jgiven-html-app/build.gradle
+++ b/jgiven-html-app/build.gradle
@@ -1,36 +1,28 @@
-import org.gradle.internal.os.OperatingSystem;
+apply plugin: 'com.github.node-gradle.node'
 
 def distDir = "${buildDir}/package/dist"
 
 def htmlAppVersion = '1.0.0'
 
-task npmPack(type: CrossPlatformExec) {
-    buildCommand('npm', 'pack', 'jgiven-html-app@'+htmlAppVersion)
+node {
+    download true
+}
+
+task npmPack(type: NpmTask) {
+    args = ['pack', "jgiven-html-app@${htmlAppVersion}"]
 
     doLast {
-      copy {
-         from tarTree(resources.gzip('jgiven-html-app-'+htmlAppVersion+'.tgz'))
-         into buildDir
-      }
+        copy {
+            from tarTree(resources.gzip("jgiven-html-app-${htmlAppVersion}.tgz"))
+            into buildDir
+        }
     }
 }
 
 task zipAppDir(type: Zip, dependsOn: npmPack) {
     from distDir
-    archiveName = 'app.zip'
-    destinationDir = new File(buildDir, 'resources/main/com/tngtech/jgiven/report/html5')
+    archiveFileName = 'app.zip'
+    destinationDirectory = new File(buildDir, 'resources/main/com/tngtech/jgiven/report/html5')
 }
 
 jar.dependsOn zipAppDir
-
-class CrossPlatformExec extends Exec {
-    void buildCommand(String command, String... commandArgs) {
-        if(OperatingSystem.current().isWindows()) {
-            executable = 'cmd'
-            args = ['/c', command]
-        } else {
-            executable = command
-        }
-        args(commandArgs.toList());
-    }
-}


### PR DESCRIPTION
Using the `com.github.node-gradle.node` plugin we get OS independence out of the box. I also set `node.download = true` to automatically download and install a build-local version of NPM without relying on a globally installed distribution.