### PR TITLE
Enable automatic OSS-Release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ nexusStaging {
     packageGroup = 'com.tngtech'
     username = sonatypeUsername
     password = sonatypePassword
+    numberOfRetries = 30
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ apply plugin: 'project-report'
 description = 'JGiven - BDD in plain Java'
 def jacocoEnabled = !JavaVersion.current().isJava11Compatible();
 
+
+
 wrapper {
     gradleVersion = '6.0.1'
     distributionType = Wrapper.DistributionType.ALL
@@ -21,7 +23,6 @@ allprojects {
     group = 'com.tngtech.jgiven'
     version = version
     ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
-    ext.isCI = System.env.CI == "true"
     if (jacocoEnabled) {
         apply plugin: 'jacoco'
     }
@@ -32,6 +33,13 @@ allprojects {
     tasks.withType(Javadoc) {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
+
+    ext.sonatypeUsername = (rootProject.hasProperty('sonatypeUsername')) ?
+            rootProject.sonatypeUsername :
+            System.getenv().getOrDefault("SONATYPE_USERNAME", "")
+    ext.sonatypePassword = (rootProject.hasProperty('sonatypePassword')) ?
+            rootProject.sonatypePassword :
+            System.getenv().getOrDefault("SONATYPE_PASSWORD", "")
 }
 
 
@@ -43,6 +51,8 @@ asciidoctor {
 nexusStaging {
     stagingProfileId = stagingProfileId // stagingProfileId must be defined externally
     packageGroup = 'com.tngtech'
+    username = sonatypeUsername
+    password = sonatypePassword
 }
 
 subprojects {
@@ -245,17 +255,10 @@ configure(subprojects) {
         required {
             isReleaseVersion && gradle.taskGraph.hasTask('uploadArchives')
         }
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        useInMemoryPgpKeys(signingKey, signingPassword)
         sign configurations.archives
-    }
-
-    ext {
-        sonatypeUsername = (rootProject.hasProperty('sonatypeUsername')) ?
-                rootProject.sonatypeUsername :
-                "$System.env.SONATYPE_USERNAME"
-
-        sonatypePassword = (rootProject.hasProperty('sonatypePassword')) ?
-                rootProject.sonatypePassword :
-                "$System.env.SONATYPE_PASSWORD"
     }
 
     uploadArchives {
@@ -329,11 +332,11 @@ configure(subprojects) {
     }
 
     uploadArchives.onlyIf {
-        !(isCI && isReleaseVersion)
+        isReleaseVersion
     }
 
     uploadArchives.doFirst {
-        if (!isCI && isReleaseVersion && !JavaVersion.current().isJava8Compatible()) {
+        if (isReleaseVersion && !JavaVersion.current().isJava8Compatible()) {
             throw new GradleException("Releases have to be done with Java 8");
         }
     }

--- a/example-projects/junit5/build.gradle
+++ b/example-projects/junit5/build.gradle
@@ -1,10 +1,18 @@
-plugins {
-  id "com.tngtech.jgiven.gradle-plugin" version "${version}"
+buildscript {
+    repositories {
+        if (project.hasProperty('staging')) {
+            maven { url "https://oss.sonatype.org/content/repositories/staging/" }
+        }
+        mavenLocal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.tngtech.jgiven:jgiven-gradle-plugin:${version}"
+    }
 }
 
+apply plugin: 'com.tngtech.jgiven.gradle-plugin'
 apply plugin: 'java'
-apply plugin: 'idea'
-apply plugin: 'eclipse'
 
 compileJava {
     sourceCompatibility = 1.8
@@ -19,10 +27,13 @@ ext {
 }
 
 repositories {
+    if (project.hasProperty('staging')) {
+        maven { url "https://oss.sonatype.org/content/repositories/staging/" }
+    }
     mavenLocal()
     mavenCentral()
     jcenter()
- }
+}
 
 dependencies {
     testCompile 'com.tngtech.jgiven:jgiven-junit5:' + jgivenVersion


### PR DESCRIPTION
The changes needed to enables an automatic OSS-Release via Github include
- Provide credentials from environment variables as there is no gradle.properties
- When triggered by a CI workflow the release should always happen.
- gradle plugin test should use the artifact on the oss.sonatype staging repo similar to the maven plugin test 
