### PR TITLE
Issue-478: separate maven from gradle plugin publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -292,7 +292,7 @@ configure(subprojects) {
     signing {
         // requires gradle.properties, see http://www.gradle.org/docs/current/userguide/signing_plugin.html
         required {
-            isReleaseVersion && gradle.taskGraph.hasTask('publish')
+            isReleaseVersion && gradle.taskGraph.getAllTasks().any{it instanceof PublishToMavenRepository}
         }
         def signingKey = findProperty("signingKey")
         def signingPassword = findProperty("signingPassword")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,7 +38,7 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 echo Building, Testing, and Uploading Archives...
-./gradlew --no-parallel clean test publish
+./gradlew --no-parallel clean test publishMavenPublicationToMavenRepository
 
 echo Creating Tag
 git tag -a -m $VERSION_PREFIXED $VERSION_PREFIXED


### PR DESCRIPTION
When using the catchall 'publish' tasks, gradle would execute the publication to maven and the publication to gradle in the same run. Since these two task produce a publication with the exact same coordinates, but different metadata (pom vs no pom) the latter would overwrite the former leading to a failure of the sonatype pom verification.

Signed-off-by: l-1squared <30831153+l-1squared@users.noreply.github.com>

I have checked that the "multiple publication message under same coordinates" does not appear anymore, also I have checked that the "publishPlugins" task is not excluded by the changes to the signing plugin (in fact it does not seem that the signing requirement is checked under "publishPlugins")