### PR TITLE
Fixes #494, i.e. the bug that additional stages in JUnit5 are not injected as Spring Beans.

### DIFF
--- a/jgiven-spring-junit4/src/test/java/com/tngtech/jgiven/integration/spring/test/AdditionalStageTest.java
+++ b/jgiven-spring-junit4/src/test/java/com/tngtech/jgiven/integration/spring/test/AdditionalStageTest.java
@@ -1,0 +1,43 @@
+package com.tngtech.jgiven.integration.spring.test;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ScenarioStage;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import com.tngtech.jgiven.integration.spring.SimpleSpringScenarioTest;
+import com.tngtech.jgiven.integration.spring.config.TestSpringConfig;
+
+@RunWith( SpringJUnit4ClassRunner.class )
+@ContextConfiguration( classes = TestSpringConfig.class )
+public class AdditionalStageTest extends SimpleSpringScenarioTest<SimpleTestSpringSteps> {
+
+    @ScenarioStage
+    AdditionalStage additionalStage;
+
+    @Test
+    public void beans_are_injected_in_additional_stages() {
+        given().a_step_that_is_a_spring_component();
+        when().methods_on_this_component_are_called();
+        additionalStage.then().beans_are_injected();
+    }
+
+    @JGivenStage
+    static class AdditionalStage extends Stage<AdditionalStage> {
+
+        private final TestBean testBean;
+
+        AdditionalStage(TestBean testBean) {
+            this.testBean = testBean;
+        }
+
+        public void beans_are_injected() {
+            Assertions.assertThat( testBean ).isNotNull();
+        }
+    }
+}

--- a/jgiven-spring-junit5/src/main/java/com/tngtech/jgiven/integration/spring/junit5/DualSpringScenarioTest.java
+++ b/jgiven-spring-junit5/src/main/java/com/tngtech/jgiven/integration/spring/junit5/DualSpringScenarioTest.java
@@ -1,13 +1,14 @@
 package com.tngtech.jgiven.integration.spring.junit5;
 
-import com.tngtech.jgiven.junit5.DualScenarioTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.tngtech.jgiven.base.DualScenarioTestBase;
+import com.tngtech.jgiven.impl.Scenario;
 import com.tngtech.jgiven.integration.spring.SpringStageCreator;
-import com.tngtech.jgiven.junit5.SimpleScenarioTest;
+import com.tngtech.jgiven.junit5.JGivenExtension;
 
 /**
  * Base class for Spring 5 and JUnit 5 test with two stage class parameter
@@ -17,9 +18,16 @@ import com.tngtech.jgiven.junit5.SimpleScenarioTest;
  *
  * @since 1.0.0
  */
-@ExtendWith( SpringExtension.class )
+@ExtendWith( {SpringExtension.class, JGivenExtension.class} )
 public class DualSpringScenarioTest<GIVEN_WHEN, THEN> extends
-        DualScenarioTest<GIVEN_WHEN, THEN> implements BeanFactoryAware {
+        DualScenarioTestBase<GIVEN_WHEN, THEN> implements BeanFactoryAware {
+
+    private Scenario<GIVEN_WHEN,GIVEN_WHEN, THEN> scenario = createScenario();
+
+    @Override
+    public Scenario<GIVEN_WHEN, GIVEN_WHEN, THEN> getScenario() {
+        return scenario;
+    }
 
     @Override
     public void setBeanFactory( BeanFactory beanFactory ) {

--- a/jgiven-spring-junit5/src/main/java/com/tngtech/jgiven/integration/spring/junit5/SimpleSpringScenarioTest.java
+++ b/jgiven-spring-junit5/src/main/java/com/tngtech/jgiven/integration/spring/junit5/SimpleSpringScenarioTest.java
@@ -1,13 +1,14 @@
 package com.tngtech.jgiven.integration.spring.junit5;
 
-import com.tngtech.jgiven.junit5.SimpleScenarioTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.tngtech.jgiven.base.SimpleScenarioTestBase;
+import com.tngtech.jgiven.impl.Scenario;
 import com.tngtech.jgiven.integration.spring.SpringStageCreator;
-import com.tngtech.jgiven.junit5.ScenarioTest;
+import com.tngtech.jgiven.junit5.JGivenExtension;
 
 /**
  * Base class for Spring 5 and JUnit 5 test with only one stage class parameter
@@ -16,9 +17,16 @@ import com.tngtech.jgiven.junit5.ScenarioTest;
  *
  * @since 1.0.0
  */
-@ExtendWith( SpringExtension.class )
+@ExtendWith( {SpringExtension.class, JGivenExtension.class} )
 public class SimpleSpringScenarioTest<STAGE> extends
-        SimpleScenarioTest<STAGE> implements BeanFactoryAware {
+        SimpleScenarioTestBase<STAGE> implements BeanFactoryAware {
+
+    private Scenario<STAGE, STAGE, STAGE> scenario = createScenario();
+
+    @Override
+    public Scenario<STAGE, STAGE, STAGE> getScenario() {
+        return scenario;
+    }
 
     @Override
     public void setBeanFactory( BeanFactory beanFactory ) {

--- a/jgiven-spring-junit5/src/main/java/com/tngtech/jgiven/integration/spring/junit5/SpringScenarioTest.java
+++ b/jgiven-spring-junit5/src/main/java/com/tngtech/jgiven/integration/spring/junit5/SpringScenarioTest.java
@@ -5,9 +5,10 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.tngtech.jgiven.base.ScenarioTestBase;
+import com.tngtech.jgiven.impl.Scenario;
 import com.tngtech.jgiven.integration.spring.SpringStageCreator;
 import com.tngtech.jgiven.junit5.JGivenExtension;
-import com.tngtech.jgiven.junit5.ScenarioTest;
 
 /**
  * Base class for Spring 5 and JUnit 5 test with three stage classes
@@ -18,9 +19,16 @@ import com.tngtech.jgiven.junit5.ScenarioTest;
  *
  * @since 1.0.0
  */
-@ExtendWith( SpringExtension.class )
+@ExtendWith( {SpringExtension.class, JGivenExtension.class} )
 public class SpringScenarioTest<GIVEN, WHEN, THEN> extends
-        ScenarioTest<GIVEN, WHEN, THEN> implements BeanFactoryAware {
+        ScenarioTestBase<GIVEN, WHEN, THEN> implements BeanFactoryAware {
+
+    private Scenario<GIVEN, WHEN, THEN> scenario = createScenario();
+
+    @Override
+    public Scenario<GIVEN, WHEN, THEN> getScenario() {
+        return scenario;
+    }
 
     @Override
     public void setBeanFactory( BeanFactory beanFactory ) {

--- a/jgiven-spring-junit5/src/test/java/com/tngtech/jgiven/integration/spring/junit5/test/AdditionalStageTest.java
+++ b/jgiven-spring-junit5/src/test/java/com/tngtech/jgiven/integration/spring/junit5/test/AdditionalStageTest.java
@@ -1,0 +1,76 @@
+package com.tngtech.jgiven.integration.spring.junit5.test;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ScenarioStage;
+import com.tngtech.jgiven.integration.spring.JGivenStage;
+import com.tngtech.jgiven.integration.spring.junit5.DualSpringScenarioTest;
+import com.tngtech.jgiven.integration.spring.junit5.SimpleSpringScenarioTest;
+import com.tngtech.jgiven.integration.spring.junit5.SpringScenarioTest;
+import com.tngtech.jgiven.integration.spring.junit5.config.TestSpringConfig;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration( classes = TestSpringConfig.class )
+public class AdditionalStageTest extends SimpleSpringScenarioTest<SimpleTestSpringSteps> {
+
+    @Nested
+    @ContextConfiguration( classes = TestSpringConfig.class )
+    class SimpleTest extends SimpleSpringScenarioTest<SimpleTestSpringSteps> {
+        @ScenarioStage
+        AdditionalStage additionalStage;
+
+        @Test
+        public void beans_are_injected_in_additional_stages() {
+            additionalStage.when().an_additional_stage_is_injected();
+            additionalStage.then().spring_beans_of_this_stage_are_injected();
+        }
+    }
+
+    @Nested
+    @ContextConfiguration( classes = TestSpringConfig.class )
+    class DualTest extends DualSpringScenarioTest<SimpleTestSpringSteps, SimpleTestSpringSteps> {
+        @ScenarioStage
+        AdditionalStage additionalStage;
+
+        @Test
+        public void beans_are_injected_in_additional_stages() {
+            additionalStage.when().an_additional_stage_is_injected();
+            additionalStage.then().spring_beans_of_this_stage_are_injected();
+        }
+
+    }
+
+    @Nested
+    @ContextConfiguration( classes = TestSpringConfig.class )
+    class GivenWhenThenStagesTest extends SpringScenarioTest<SimpleTestSpringSteps, SimpleTestSpringSteps, SimpleTestSpringSteps> {
+        @ScenarioStage
+        AdditionalStage additionalStage;
+
+        @Test
+        public void beans_are_injected_in_additional_stages() {
+            additionalStage.when().an_additional_stage_is_injected();
+            additionalStage.then().spring_beans_of_this_stage_are_injected();
+        }
+    }
+
+    @JGivenStage
+    static class AdditionalStage extends Stage<AdditionalStage> {
+        private final TestBean testBean;
+
+        AdditionalStage(TestBean testBean) {
+            this.testBean = testBean;
+        }
+
+        public AdditionalStage an_additional_stage_is_injected() {
+            return this;
+        }
+
+        public AdditionalStage spring_beans_of_this_stage_are_injected() {
+            Assertions.assertThat( testBean ).isNotNull();
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
Note that the JUnit5 Extensions have to be executed in the correct order, meaning the SpringExtension must run before the JGivenExtension. This is now enforced. Unfortunately, the original JUnit5 ScenarioTest (and similar) cannot be used any longer because they already contain the JGivenExtension.

Signed-off-by: Fabian Kneißl <fabian.kneissl@tngtech.com>

Note that it would be good to also merge #493 so that the tests are actually executed :)