### PR TITLE
Issue-478: also publish artifacts to local repository on release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -52,7 +52,7 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 echo Building, Testing, and Uploading Archives...
-./gradlew --no-parallel clean test publishMavenPublicationToMavenRepository ${GRADLE_PROPERTIES}
+./gradlew --no-parallel clean test  publishMavenPublicationToMavenLocal publishMavenPublicationToMavenRepository ${GRADLE_PROPERTIES}
 
 echo Creating Tag
 git tag -a -m "${VERSION_PREFIXED}" "${VERSION_PREFIXED}"


### PR DESCRIPTION
Currently the maven plugin build fails, because its maven build tries to collect the jgiven artifacts of the version being released from maven central, which cannot go well. If there is a copy of them in the local repo the build should work

Signed-off-by: l-1squared <30831153+l-1squared@users.noreply.github.com>