### PR TITLE
Issue-478: ensure the property finders output is handled correctly

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,7 +38,8 @@ fi
 
 VERSION="$1"
 VERSION_PREFIXED="v$1"
-GRADLE_PROPERTIES="$(find_gradle_property "$@")"
+declare -a GRADLE_PROPERTIES
+find_gradle_property GRADLE_PROPERTIES "$@"
 
 echo Releasing version "${VERSION}"
 
@@ -52,13 +53,13 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 echo Building, Testing, and Uploading Archives...
-./gradlew --no-parallel clean test  publishMavenPublicationToMavenLocal publishMavenPublicationToMavenRepository ${GRADLE_PROPERTIES}
+./gradlew --no-parallel clean test  publishMavenPublicationToMavenLocal publishMavenPublicationToMavenRepository "${GRADLE_PROPERTIES[@]}"
 
 echo Creating Tag
 git tag -a -m "${VERSION_PREFIXED}" "${VERSION_PREFIXED}"
 
 echo Closing the repository...
-./gradlew closeRepository "${GRADLE_PROPERTIES}"
+./gradlew closeRepository "${GRADLE_PROPERTIES[@]}"
 
 echo Testing staging version...
 
@@ -66,7 +67,7 @@ echo Testing Maven plugin from staging repository...
 mvn -f example-projects/maven/pom.xml clean test -Djgiven.version="${VERSION}"
 
 echo Testing Gradle plugin from staging repository...
-./gradlew -b example-projects/junit5/build.gradle clean test -Pstaging -Pversion="${VERSION}" "${GRADLE_PROPERTIES}"
+./gradlew -b example-projects/junit5/build.gradle clean test -Pstaging -Pversion="${VERSION}" "${GRADLE_PROPERTIES[@]}"
 
 echo STAGING SUCCESSFUL!
 

--- a/scripts/release_functions.sh
+++ b/scripts/release_functions.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 function find_gradle_property(){
+    [[ "$(declare -p $1 2>/dev/null)" =~ "declare -a" ]] || return 11
+    local -n output_target=$1
     for command_line_argument in "$@"; do
-        gradle_properties=""
         if [[ "${command_line_argument}" =~ ^-P.*=.* ]];then
-          gradle_properties="${gradle_properties} ${command_line_argument}"
+          output_target+=("${command_line_argument}")
         fi
-        printf "%s" "${gradle_properties}"
     done
 }
 

--- a/scripts/test_release_functions.sh
+++ b/scripts/test_release_functions.sh
@@ -4,18 +4,55 @@ SCRIPT_LOCATION=$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")
 # shellcheck source=./release_functions.sh
 source "${SCRIPT_LOCATION}"/release_functions.sh
 
+test_find_gradle_property_check_fails_if_variable_is_undeclared(){
+  unset undeclared_variable # Just to be safe that our test variable is not declared
+  find_gradle_property undeclared_variable -Pkey=value || return 0
+  printf "Expected function to fail on an undeclared variable"
+  return 1
+}
+
+test_find_gradle_property_check_fails_if_variable_is_not_an_array(){
+  local not_an_array_variable
+  find_gradle_property not_an_array_variable -Pkey=value || return 0
+  printf "Expected function to fail if variable is not an array"
+  return 1
+}
+
+test_find_gradle_property_writes_to_array_variable(){
+  local -a an_empty_array
+  find_gradle_property an_empty_array -Pkey=value
+  [ "${#an_empty_array[@]}" -eq 1 ] && return 0
+  printf "Expected function to write to variable"
+  return 1
+}
+
 test_find_gradle_property_extracts_property(){
   expected_output="-PsecretKey=secret -PsecretPassword=password"
-  output=$(find_gradle_property release.sh 1.0.0 "${expected_output}")
-  [ "${output}" != "${expected_output}" ] || return 1
-  return 0
+  local -a output_array
+  find_gradle_property release.sh 1.0.0 "${expected_output}"
+  printf "Expected \"%s\", got \"%s\"" "${expected_output}" "${output}"
+  [ "${output_array[@]}" == "${expected_output}" ] || return 1 && return 0
 }
 
 test_find_gradle_property_handles_spaces(){
-  expected_output="-Pkey='a name'"
-  output=$(find_gradle_property release.sh 1.0.0 "${expected_output}")
-  [ "${output}" != "${expected_output}" ] || return 1
-  return 0
+  expected_output="-Pkey=a name"
+  local -a output_array
+  find_gradle_property release.sh 1.0.0 "${expected_output}"
+  printf "Expected \"%s\", got \"%s\"" "${expected_output}" "${output}"
+  [ "${output_array[@]}" == "${expected_output}" ] || return 1 && return 0
+}
+
+test_properties_are_passed_on_correctly(){
+  local -a properties
+  find_gradle_property properties release.sh 1.0.0 -Pkey="a value" -Pkey2=value2
+  function count_arguments(){
+    echo $#
+  }
+  actual_argument_number=$(count_arguments "${properties[@]}")
+  expected_argument_number=2
+  printf "Expected %d arguments, got %d" "${expected_argument_number}" "${actual_argument_number}"
+  [ "${actual_argument_number}" -eq "${expected_argument_number}" ] || return 1 && return 0
+
 }
 
 run_tests(){
@@ -35,4 +72,9 @@ run_tests(){
   printf "Ran Tests: %2d successful, %2d failed, %2d total\n" $((total_tests - failed_tests)) ${failed_tests} ${total_tests}
 }
 
-run_tests "test_find_gradle_property_extracts_property" "test_find_gradle_property_handles_spaces"
+run_tests "test_find_gradle_property_extracts_property" \
+"test_find_gradle_property_handles_spaces" \
+"test_properties_are_passed_on_correctly" \
+"test_find_gradle_property_check_fails_if_variable_is_undeclared" \
+"test_find_gradle_property_check_fails_if_variable_is_not_an_array" \
+"test_find_gradle_property_writes_to_array_variable"


### PR DESCRIPTION
It turns out that there is no way to return a string or an array with elements that themselves contain spaces in a way that bash will interpret the elements correctly (i.e. var1, var 2, var3 -> var1, var, 2, var3). The solution is to use bash's nameref feature. This allows a function to write to a variable directly without knowing the actual variable name.

Signed-off-by: l-1squared <30831153+l-1squared@users.noreply.github.com>