### PR TITLE
Issue-478: set asciidoc base dir manually and bump version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.kt3k.coveralls' version '2.8.4'
-    id 'org.asciidoctor.jvm.convert' version '2.3.0'
+    id 'org.asciidoctor.jvm.convert' version '3.0.0'
     id 'io.codearte.nexus-staging' version '0.21.1'
     id 'com.github.ben-manes.versions' version '0.27.0'
     id 'org.sonarqube' version '2.8' apply false
@@ -36,6 +36,7 @@ allprojects {
 }
 
 asciidoctor {
+    baseDir = file('docs')
     sourceDir = file('docs')
     attributes 'version': version
 }


### PR DESCRIPTION
Asiidoc used the directory from where the corresponding gradle task was executed as the base directory to resolve relative incluedes. Naturally this led to paths that could not be resolved. Also bump version to 3.0.0

Signed-off-by: l-1squared <30831153+l-1squared@users.noreply.github.com>