### PR TITLE
Add signoff message for renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,6 @@
   ],
   "ignorePaths": [
     "**/example-projects/scala/**"
-  ]
+  ],
+  "commitBody": "Signed-off-by: l-1squared <30831153+l-1squared@users.noreply.github.com>"
 }


### PR DESCRIPTION
Because, otherwise the DCO check will always fail

Signed-off-by: l-1squared <30831153+l-1squared@users.noreply.github.com>