### PR TITLE
add correct signoff message

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,5 @@
   "ignorePaths": [
     "**/example-projects/scala/**"
   ],
-  "commitBody": "Signed-off-by: l-1squared <30831153+l-1squared@users.noreply.github.com>"
+  "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>"
 }


### PR DESCRIPTION
Given the reports from the still failing DCO check, this should be the correct way to do it

Signed-off-by: l-1squared <30831153+l-1squared@users.noreply.github.com>