### PR TITLE
Issue-558: group and schedule Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,35 @@
   "ignorePaths": [
     "**/example-projects/scala/**"
   ],
-  "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>"
+  "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>",
+  "prCreation": "not-pending",
+  "additionalReviewers": [
+    "fudler",
+    "l-1squared"
+  ],
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "slf4j"
+      ],
+      "groupName": "slf4j"
+    },
+    {
+      "packagePatterns": [
+        "junit.jupiter"
+      ],
+      "groupName": "junit5"
+    },
+    {
+      "packagePatterns": [
+        "powermock"
+      ],
+      "groupName": "powermock"
+    }
+  ],
+  "schedule": [
+    "after 10pm every weekday",
+    "before 5am every weekday",
+    "every weekend"
+  ]
 }


### PR DESCRIPTION
The massive amount of Renovate PRs generate a lot of noise. Out of the options to reduce that noise, I chose to first just group automerge PR and limit the time at which the will be opened. The most powerful noise-reduction feature, branch-automerge, is currently incompatible with the repos branch protection settings, also I am not yet sure for which types of updates I should activate that.

Signed-off-by: l-1squared <30831153+l-1squared@users.noreply.github.com>