### PR TITLE
fix for issue #366 nested steps not showing attachments in html report

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/ScenarioCaseModel.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/ScenarioCaseModel.java
@@ -61,12 +61,19 @@ public class ScenarioCaseModel {
      */
     private String description;
 
-    public void accept( ReportModelVisitor visitor ) {
-        visitor.visit( this );
-        for( StepModel step : getSteps() ) {
-            step.accept( visitor );
+     public void accept(ReportModelVisitor visitor) {
+      visitor.visit(this);
+      visitStepsRecursively(visitor, getSteps());
+      visitor.visitEnd(this);
+    }
+
+    private void visitStepsRecursively(ReportModelVisitor visitor, List<StepModel> steps) {
+      for (StepModel step : steps) {
+        step.accept(visitor);
+        if (!step.getNestedSteps().isEmpty()) {
+          visitStepsRecursively(visitor, step.getNestedSteps());
         }
-        visitor.visitEnd( this );
+      }
     }
 
     public void addExplicitArguments( String... args ) {


### PR DESCRIPTION
By visiting all steps including nested Steps in ScenarioCaseModel, Html5AttachmentGenerator will find all Attachments in JsonReport