### PR TITLE
remove jcenter repo from built

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,17 +1,12 @@
 pluginManagement {
     plugins {
-        id 'com.tngtech.jgiven.gradle-plugin' version '1.0.0-RC4'
+        id 'com.tngtech.jgiven.gradle-plugin' version "${version}"
 
     }
 
     repositories {
         gradlePluginPortal()
-        jcenter()
         google()
-        maven {
-            name "JCenter Gradle Plugins"
-            url "https://dl.bintray.com/gradle/gradle-plugins"
-        }
         maven {
            url "https://oss.sonatype.org/content/repositories/snapshots/"
         }


### PR DESCRIPTION
the jcenter and bintray repocitories are scheduled to close down at the end of may 2021.

Signed-off-by: l-1sqared <30831153+l-1squared@users.noreply.github.com>