### PR TITLE
Fix for issue #366 nested steps not showing attachments in html report

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/ScenarioCaseModel.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/ScenarioCaseModel.java
@@ -61,12 +61,20 @@ public class ScenarioCaseModel {
      */
     private String description;
 
-    public void accept( ReportModelVisitor visitor ) {
-        visitor.visit( this );
-        for( StepModel step : getSteps() ) {
-            step.accept( visitor );
+    public void accept(ReportModelVisitor visitor) {
+        visitor.visit(this);
+        visitStepsRecursively(visitor, getSteps(), 0);
+        visitor.visitEnd(this);
+    }
+
+    private void visitStepsRecursively(ReportModelVisitor visitor, List<StepModel> steps, int depth) {
+        for (StepModel step : steps) {
+            step.setDepth(depth);
+            step.accept(visitor);
+            if (!step.getNestedSteps().isEmpty()) {
+                visitStepsRecursively(visitor, step.getNestedSteps(), depth + 1);
+            }
         }
-        visitor.visitEnd( this );
     }
 
     public void addExplicitArguments( String... args ) {

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/ScenarioCaseModel.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/ScenarioCaseModel.java
@@ -61,18 +61,18 @@ public class ScenarioCaseModel {
      */
     private String description;
 
-    public void accept(ReportModelVisitor visitor) {
-        visitor.visit(this);
-        visitStepsRecursively(visitor, getSteps(), 0);
-        visitor.visitEnd(this);
+    public void accept( ReportModelVisitor visitor ) {
+        visitor.visit( this );
+        visitStepsRecursively( visitor, getSteps(), 0 );
+        visitor.visitEnd( this );
     }
 
-    private void visitStepsRecursively(ReportModelVisitor visitor, List<StepModel> steps, int depth) {
-        for (StepModel step : steps) {
-            step.setDepth(depth);
-            step.accept(visitor);
-            if (!step.getNestedSteps().isEmpty()) {
-                visitStepsRecursively(visitor, step.getNestedSteps(), depth + 1);
+    private void visitStepsRecursively( ReportModelVisitor visitor, List<StepModel> steps, int depth ) {
+        for( StepModel step : steps ) {
+            step.setDepth( depth );
+            step.accept( visitor );
+            if( !step.getNestedSteps().isEmpty() ) {
+                visitStepsRecursively( visitor, step.getNestedSteps(), depth + 1 );
             }
         }
     }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/StepModel.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/StepModel.java
@@ -65,6 +65,16 @@ public class StepModel {
      */
     private String comment;
 
+    /**
+     * The depth of the step.
+     */
+    private int depth;
+    
+    /**
+     * Indicates if the parent step has failed.
+     */
+    private boolean parentFailed;
+
     public StepModel() {
     }
 
@@ -223,6 +233,22 @@ public class StepModel {
 
     public boolean hasAttachment() {
         return !getAttachments().isEmpty();
+    }
+
+    public int getDepth() {
+      return depth;
+    }
+
+    public void setDepth(int depth) {
+      this.depth = depth;
+    }
+
+    public boolean isParentFailed() {
+      return parentFailed;
+    }
+
+    public void setParentFailed(boolean parentFailed) {
+      this.parentFailed = parentFailed;
     }
 
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/StepModel.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/StepModel.java
@@ -69,7 +69,7 @@ public class StepModel {
      * The depth of the step.
      */
     private int depth;
-    
+
     /**
      * Indicates if the parent step has failed.
      */
@@ -236,19 +236,19 @@ public class StepModel {
     }
 
     public int getDepth() {
-      return depth;
+        return depth;
     }
 
-    public void setDepth(int depth) {
-      this.depth = depth;
+    public void setDepth( int depth ) {
+        this.depth = depth;
     }
 
     public boolean isParentFailed() {
-      return parentFailed;
+        return parentFailed;
     }
 
-    public void setParentFailed(boolean parentFailed) {
-      this.parentFailed = parentFailed;
+    public void setParentFailed( boolean parentFailed ) {
+        this.parentFailed = parentFailed;
     }
 
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/text/PlainTextScenarioWriter.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/text/PlainTextScenarioWriter.java
@@ -90,18 +90,18 @@ public class PlainTextScenarioWriter extends PlainTextWriter {
 
     @Override
     public void visit( StepModel stepModel ) {
-      if (stepModel.isFailed()&& stepModel.getNestedSteps()!=null) {
-        for (StepModel step : stepModel.getNestedSteps()) {
-          step.setParentFailed(true);
+        if( stepModel.isFailed() && stepModel.getNestedSteps() != null ) {
+            for( StepModel step : stepModel.getNestedSteps() ) {
+                step.setParentFailed( true );
+            }
         }
-      }
         printStep( stepModel, false );
         firstStep = false;
     }
 
     private void printStep( StepModel stepModel, boolean showPassed ) {
         List<Word> words = stepModel.getWords();
-       
+
         if( stepModel.isSectionTitle() ) {
             printSectionTitle( stepModel );
             return;
@@ -127,7 +127,7 @@ public class PlainTextScenarioWriter extends PlainTextWriter {
             line = gray( line + " (skipped)" );
         } else if( stepModel.isFailed() ) {
             line = boldRed( line + " (failed)" );
-        } else if( showPassed || stepModel.getDepth() > 0 && stepModel.isParentFailed()) {
+        } else if( showPassed || stepModel.getDepth() > 0 && stepModel.isParentFailed() ) {
             line = green( line + " (passed)" );
         }
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/text/PlainTextScenarioWriter.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/text/PlainTextScenarioWriter.java
@@ -90,19 +90,24 @@ public class PlainTextScenarioWriter extends PlainTextWriter {
 
     @Override
     public void visit( StepModel stepModel ) {
-        printStep( stepModel, 0, false );
+      if (stepModel.isFailed()&& stepModel.getNestedSteps()!=null) {
+        for (StepModel step : stepModel.getNestedSteps()) {
+          step.setParentFailed(true);
+        }
+      }
+        printStep( stepModel, false );
         firstStep = false;
     }
 
-    private void printStep( StepModel stepModel, int depth, boolean showPassed ) {
+    private void printStep( StepModel stepModel, boolean showPassed ) {
         List<Word> words = stepModel.getWords();
-
+       
         if( stepModel.isSectionTitle() ) {
             printSectionTitle( stepModel );
             return;
         }
 
-        String introString = getIntroString( words, depth );
+        String introString = getIntroString( words, stepModel.getDepth() );
 
         int restSize = words.size();
         boolean printDataTable = false;
@@ -122,7 +127,7 @@ public class PlainTextScenarioWriter extends PlainTextWriter {
             line = gray( line + " (skipped)" );
         } else if( stepModel.isFailed() ) {
             line = boldRed( line + " (failed)" );
-        } else if( showPassed ) {
+        } else if( showPassed || stepModel.getDepth() > 0 && stepModel.isParentFailed()) {
             line = green( line + " (passed)" );
         }
 
@@ -131,8 +136,6 @@ public class PlainTextScenarioWriter extends PlainTextWriter {
         }
 
         writer.println( line );
-
-        printNestedSteps( stepModel, depth, showPassed );
 
         if( printDataTable ) {
             writer.println();
@@ -165,12 +168,6 @@ public class PlainTextScenarioWriter extends PlainTextWriter {
             }
         }
         return intro;
-    }
-
-    private void printNestedSteps( StepModel stepModel, int depth, boolean showPassed ) {
-        for( StepModel nestedStepModel : stepModel.getNestedSteps() ) {
-            printStep( nestedStepModel, depth + 1, stepModel.getStatus() == StepStatus.FAILED || showPassed );
-        }
     }
 
     private void printDataTable( Word word ) {

--- a/jgiven-html5-report/src/test/java/com/tngtech/jgiven/report/html5/Html5AttachmentGeneratorTest.java
+++ b/jgiven-html5-report/src/test/java/com/tngtech/jgiven/report/html5/Html5AttachmentGeneratorTest.java
@@ -72,16 +72,19 @@ public class Html5AttachmentGeneratorTest {
     }
 
     @Test
-    public void testFindingAndGeneratingAttachmentsInAllSteps() {
+    public void testFindingAndGeneratingAttachmentsInAllSteps() throws IOException {
         Html5AttachmentGenerator generator = new Html5AttachmentGenerator( temporaryFolderRule.getRoot() );
         File root = temporaryFolderRule.getRoot();
         generator.generateAttachments( root, generateReportModelWithAttachments() );
 
-        File parentStepFile = new File( temporaryFolderRule.getRoot().getPath() + "/parentAttachment.gif" );
-        File nestedStepFile = new File( temporaryFolderRule.getRoot().getPath() + "/nestedAttachment.gif" );
+        File parentStepFile = new File( temporaryFolderRule.getRoot().getPath() + "/attachments/testing/parentAttachment.gif" );
+        File nestedStepFile = new File( temporaryFolderRule.getRoot().getPath() + "/attachments/testing/nestedAttachment.gif" );
+        
+        Attachment writtenParentAttachment = Attachment.fromBinaryFile( parentStepFile, MediaType.GIF );
+        Attachment writtenNestedAttachment = Attachment.fromBinaryFile( nestedStepFile, MediaType.GIF );
+        assertThat( writtenParentAttachment.getContent() ).isNotNull();
+        assertThat( writtenNestedAttachment.getContent() ).isNotNull();
 
-        assertThat( parentStepFile.exists() );
-        assertThat( nestedStepFile.exists() );
     }
 
     private ReportModel generateReportModelWithAttachments() {
@@ -100,7 +103,7 @@ public class Html5AttachmentGeneratorTest {
         scenarioModel.addCase( scenarioCase );
         scenarios.add( scenarioModel );
         model.setScenarios( scenarios );
-        model.setClassName( "testFindingAndGeneratingAttachmentsInNestedSteps" );
+        model.setClassName( "testing" );
         return model;
     }
 


### PR DESCRIPTION
Fix for issue #366 nested steps not showing attachments in html report

Added recursive visiting of nested steps in ScenarioCaseModel so that all attachments of nested steps will be found and shown in report.
PlainTextScenarioWriter had to be adjusted so that it uses the nested steps found by the visitor for the plain text report. In order to work as before two new attributes were added to StepModel.