### PR TITLE
Add documentation for gradle plugin

### DIFF
--- a/docs/report_generation.adoc
+++ b/docs/report_generation.adoc
@@ -156,6 +156,8 @@ plugins {
 }
 ----
 
+When using Kotlin, make sure the JGiven Gradle plugin is configured _after_ the `kotlin("jvm")` plugin.
+
 Alternatively you can configure the plugin as follows:
 
 [source,gradle,subs="verbatim,attributes"]


### PR DESCRIPTION
Add documentation for build.gradle.kts file where the finalizedBy(jgivenTestReport) did not work if kotlin("jvm") plugin was placed after jgiven plugin