### PR TITLE
extract tag creation tasks from scenario model builder and refactor

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/tag/TagCreator.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/tag/TagCreator.java
@@ -1,0 +1,243 @@
+package com.tngtech.jgiven.impl.tag;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.tngtech.jgiven.annotation.IsTag;
+import com.tngtech.jgiven.config.AbstractJGivenConfiguration;
+import com.tngtech.jgiven.config.TagConfiguration;
+import com.tngtech.jgiven.exception.JGivenWrongUsageException;
+import com.tngtech.jgiven.report.model.Tag;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles the conversion of Annotations on Classes and Methods to displayable Tags.
+ */
+public class TagCreator {
+
+    private static final Logger log = LoggerFactory.getLogger(TagCreator.class);
+
+    private final AbstractJGivenConfiguration configuration;
+
+    public TagCreator(AbstractJGivenConfiguration configuration) {
+
+        this.configuration = configuration;
+    }
+
+    /**
+     * Turns an annotation class and a manually supplied set of annotation values into tags.
+     * Permits the programmatic creation of tags.
+     */
+    public List<Tag> toTags(Class<? extends Annotation> annotationClass, String... values) {
+        TagConfiguration tagConfig = toTagConfiguration(annotationClass);
+        if (tagConfig == null) {
+            return Collections.emptyList();
+        }
+
+        List<Tag> tags = processConfiguredAnnotation(tagConfig);
+        if (tags.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        if (values.length > 0) {
+            return getExplodedTags(Iterables.getOnlyElement(tags), values, null, tagConfig);
+        } else {
+            return tags;
+        }
+    }
+
+    /**
+     * Turns an annotation defined on a class or method into tags.
+     * Permits the declarative creation of tags
+     */
+    public List<Tag> toTags(Annotation annotation) {
+        Class<? extends Annotation> annotationType = annotation.annotationType();
+        TagConfiguration tagConfig = toTagConfiguration(annotationType);
+        if (tagConfig == null) {
+            return Collections.emptyList();
+        }
+
+        return processConfiguredAnnotation(tagConfig, annotation);
+    }
+
+    private List<Tag> processConfiguredAnnotation(TagConfiguration tagConfig, Annotation annotation) {
+        if (tagConfig.isIgnoreValue()) {
+            return processConfiguredAnnotation(tagConfig);
+        }
+        Tag tag = createStyledTag(tagConfig);
+        tag.setTags(tagConfig.getTags());
+
+        Optional<Object> valueOptional = getValuesFromAnnotation(annotation);
+        if (valueOptional.isPresent()) {
+            Object value = valueOptional.get();
+            if (value.getClass().isArray()) {
+                if (tagConfig.isExplodeArray()) {
+                    return getExplodedTags(tag, (Object[]) value, annotation, tagConfig);
+                } else {
+                    tag.setValue(toStringList((Object[]) value));
+                }
+            } else {
+                tag.setValue(String.valueOf(value));
+            }
+        } else {
+            setIfNotNullOrEmpty(tagConfig.getDefaultValue(), tag::setValue);
+        }
+        tag.setDescription(getDescriptionFromGenerator(tagConfig, annotation, valueOptional.orElse(null)));
+        tag.setHref(getHref(tagConfig, annotation, valueOptional.orElse(null)));
+        return Collections.singletonList(tag);
+    }
+
+    private List<Tag> processConfiguredAnnotation(TagConfiguration tagConfig) {
+        if (!tagConfig.isIgnoreValue()) {
+            log.warn(
+                "Tag configuration 'ignoreValue', set to 'false' is ignored, "
+                    + "because no annotation that could be respected was given.");
+        }
+
+        Tag tag = createStyledTag(tagConfig);
+        tag.setTags(tagConfig.getTags());
+        String value = tagConfig.getDefaultValue();
+
+        setIfNotNullOrEmpty(value, tag::setValue);
+        tag.setDescription(getDescriptionFromGenerator(tagConfig, null, value));
+        tag.setHref(getHref(tagConfig, null, value));
+
+        return Collections.singletonList(tag);
+    }
+
+    private Tag createStyledTag(TagConfiguration tagConfig) {
+        Tag tag = new Tag(tagConfig.getAnnotationFullType());
+
+        tag.setType(tagConfig.getAnnotationType());
+        tag.setPrependType(tagConfig.isPrependType());
+        tag.setShowInNavigation(tagConfig.showInNavigation());
+
+        setIfNotNullOrEmpty(tagConfig.getName(), tag::setName);
+        setIfNotNullOrEmpty(tagConfig.getCssClass(), tag::setCssClass);
+        setIfNotNullOrEmpty(tagConfig.getColor(), tag::setColor);
+        setIfNotNullOrEmpty(tagConfig.getStyle(), tag::setStyle);
+        return tag;
+    }
+
+    private void setIfNotNullOrEmpty(String value, Consumer<String> setter) {
+        if (!Strings.isNullOrEmpty(value)) {
+            setter.accept(value);
+        }
+    }
+
+    private Optional<Object> getValuesFromAnnotation(Annotation annotation) {
+        try {
+            Method method = annotation.annotationType().getMethod("value");
+            return Optional.ofNullable(method.invoke(annotation));
+        } catch (Exception e) {
+            log.error("Error while getting 'value' method of annotation " + annotation, e);
+            return Optional.empty();
+        }
+    }
+
+    TagConfiguration toTagConfiguration(Class<? extends Annotation> annotationType) {
+        IsTag isTag = annotationType.getAnnotation(IsTag.class);
+        if (isTag != null) {
+            return fromIsTag(isTag, annotationType);
+        }
+
+        return configuration.getTagConfiguration(annotationType);
+    }
+
+    private TagConfiguration fromIsTag(IsTag isTag, Class<? extends Annotation> annotationType) {
+        String name = isTag.name();
+
+        return TagConfiguration.builder(annotationType)
+            .defaultValue(isTag.value())
+            .description(isTag.description())
+            .explodeArray(isTag.explodeArray())
+            .ignoreValue(isTag.ignoreValue())
+            .prependType(isTag.prependType())
+            .name(name)
+            .descriptionGenerator(isTag.descriptionGenerator())
+            .cssClass(isTag.cssClass())
+            .color(isTag.color())
+            .style(isTag.style())
+            .tags(getTagNames(annotationType))
+            .href(isTag.href())
+            .hrefGenerator(isTag.hrefGenerator())
+            .showInNavigation(isTag.showInNavigation())
+            .build();
+    }
+
+    private List<String> getTagNames(Class<? extends Annotation> annotationType) {
+        List<Tag> tags = getTags(annotationType);
+        List<String> tagNames = Lists.newArrayList();
+        for (Tag tag : tags) {
+            tagNames.add(tag.toIdString());
+        }
+        return tagNames;
+    }
+
+    private List<Tag> getTags(Class<? extends Annotation> annotationType) {
+        List<Tag> allTags = Lists.newArrayList();
+
+        for (Annotation annotation : annotationType.getAnnotations()) {
+            if (annotation.annotationType().isAnnotationPresent(IsTag.class)) {
+                allTags.addAll(toTags(annotation));
+            }
+        }
+
+        return allTags;
+    }
+
+    private List<String> toStringList(Object[] value) {
+        List<String> values = Lists.newArrayList();
+        for (Object v : value) {
+            values.add(String.valueOf(v));
+        }
+        return values;
+    }
+
+    private String getDescriptionFromGenerator(TagConfiguration tagConfiguration, Annotation annotation, Object
+        value) {
+        try {
+            return tagConfiguration.getDescriptionGenerator().getDeclaredConstructor().newInstance()
+                .generateDescription(tagConfiguration, annotation, value);
+        } catch (Exception e) {
+            throw new JGivenWrongUsageException(
+                "Error while trying to generate the description for annotation " + annotation
+                    + " using DescriptionGenerator class "
+                    + tagConfiguration.getDescriptionGenerator() + ": " + e.getMessage(),
+                e);
+        }
+    }
+
+    private String getHref(TagConfiguration tagConfiguration, Annotation annotation, Object value) {
+        try {
+            return tagConfiguration.getHrefGenerator().getDeclaredConstructor().newInstance()
+                .generateHref(tagConfiguration, annotation, value);
+        } catch (Exception e) {
+            throw new JGivenWrongUsageException(
+                "Error while trying to generate the href for annotation " + annotation
+                    + " using HrefGenerator class "
+                    + tagConfiguration.getHrefGenerator() + ": " + e.getMessage(),
+                e);
+        }
+    }
+
+    private List<Tag> getExplodedTags(Tag originalTag, Object[] values, Annotation annotation,
+                                      TagConfiguration tagConfig) {
+        List<Tag> result = Lists.newArrayList();
+        for (Object singleValue : values) {
+            Tag newTag = originalTag.copy();
+            newTag.setValue(String.valueOf(singleValue));
+            newTag.setDescription(getDescriptionFromGenerator(tagConfig, annotation, singleValue));
+            newTag.setHref(getHref(tagConfig, annotation, singleValue));
+            result.add(newTag);
+        }
+        return result;
+    }
+}

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ScenarioModelBuilderTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ScenarioModelBuilderTest.java
@@ -3,16 +3,6 @@ package com.tngtech.jgiven.impl;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.google.common.collect.Lists;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -24,254 +14,101 @@ import com.tngtech.jgiven.WhenTestStep;
 import com.tngtech.jgiven.annotation.As;
 import com.tngtech.jgiven.annotation.DoNotIntercept;
 import com.tngtech.jgiven.annotation.IsTag;
-import com.tngtech.jgiven.report.model.*;
+import com.tngtech.jgiven.report.model.ExecutionStatus;
+import com.tngtech.jgiven.report.model.ReportModel;
+import com.tngtech.jgiven.report.model.ScenarioCaseModel;
+import com.tngtech.jgiven.report.model.ScenarioModel;
+import com.tngtech.jgiven.report.model.StepModel;
+import com.tngtech.jgiven.report.model.Tag;
+import com.tngtech.jgiven.report.model.Word;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-@RunWith( DataProviderRunner.class )
+@RunWith(DataProviderRunner.class)
 public class ScenarioModelBuilderTest extends ScenarioTestBaseForTesting<GivenTestStep, WhenTestStep, ThenTestStep> {
 
     public ScenarioModelBuilder getScenarioModelBuilder() {
         ScenarioModelBuilder scenarioModelBuilder = new ScenarioModelBuilder();
-        scenarioModelBuilder.setReportModel( new ReportModel() );
+        scenarioModelBuilder.setReportModel(new ReportModel());
         return scenarioModelBuilder;
     }
 
-    public void startScenario( String title ) {
-        getScenario().setModel( new ReportModel() );
-        getScenario().startScenario( title );
+    public void startScenario(String title) {
+        getScenario().setModel(new ReportModel());
+        getScenario().startScenario(title);
     }
 
-    @IsTag
-    @Retention( RetentionPolicy.RUNTIME )
-    @interface AnnotationWithoutValue {}
-
-    @AnnotationWithoutValue
-    static class AnnotationTestClass {}
 
     @Test
-    public void testAnnotationParsing() throws Exception {
-        List<Tag> tags = getScenarioModelBuilder().toTags( AnnotationTestClass.class.getAnnotations()[0] );
-        assertThat( tags ).hasSize( 1 );
-        assertThat( tags.get( 0 ).getName() ).isEqualTo( "AnnotationWithoutValue" );
-        assertThat( tags.get( 0 ).getValues() ).isEmpty();
-    }
-
-    @IsTag
-    @Retention( RetentionPolicy.RUNTIME )
-    @interface AnnotationWithSingleValue {
-        String value();
-    }
-
-    @AnnotationWithSingleValue( "testvalue" )
-    static class AnnotationWithSingleValueTestClass {}
-
-    @Test
-    public void testAnnotationWithValueParsing() throws Exception {
-        List<Tag> tags = getScenarioModelBuilder().toTags( AnnotationWithSingleValueTestClass.class.getAnnotations()[0] );
-        assertThat( tags ).hasSize( 1 );
-        assertThat( tags.get( 0 ).getName() ).isEqualTo( "AnnotationWithSingleValue" );
-        assertThat( tags.get( 0 ).getValues() ).containsExactly( "testvalue" );
-    }
-
-    @IsTag( name = "AnotherName" )
-    @Retention( RetentionPolicy.RUNTIME )
-    @interface AnnotationWithName {}
-
-    @AnnotationWithName( )
-    static class AnnotationWithNameTestClass {}
-
-    @Test
-    public void testAnnotationWithName() throws Exception {
-        List<Tag> tags = getScenarioModelBuilder().toTags( AnnotationWithNameTestClass.class.getAnnotations()[0] );
-        assertThat( tags ).hasSize( 1 );
-        Tag tag = tags.get( 0 );
-        assertThat( tag.getName() ).isEqualTo( "AnotherName" );
-        assertThat( tag.getValues() ).isEmpty();
-        assertThat( tag.toIdString() ).isEqualTo( this.getClass().getName() + "$AnnotationWithName" );
-    }
-
-    @IsTag( ignoreValue = true )
-    @Retention( RetentionPolicy.RUNTIME )
-    @interface AnnotationWithIgnoredValue {
-        String value();
-    }
-
-    @AnnotationWithIgnoredValue( "testvalue" )
-    static class AnnotationWithIgnoredValueTestClass {}
-
-    @Test
-    public void testAnnotationWithIgnoredValueParsing() throws Exception {
-        List<Tag> tags = getScenarioModelBuilder().toTags( AnnotationWithIgnoredValueTestClass.class.getAnnotations()[0] );
-        assertThat( tags ).hasSize( 1 );
-        Tag tag = tags.get( 0 );
-        assertThat( tag.getName() ).isEqualTo( "AnnotationWithIgnoredValue" );
-        assertThat( tag.getValues() ).isEmpty();
-        assertThat( tag.toIdString() ).isEqualTo( this.getClass().getName() + "$AnnotationWithIgnoredValue" );
-    }
-
-    @IsTag
-    @Retention( RetentionPolicy.RUNTIME )
-    @interface AnnotationWithArray {
-        String[] value();
-    }
-
-    @AnnotationWithArray( { "foo", "bar" } )
-    static class AnnotationWithArrayValueTestClass {}
-
-    @Test
-    public void testAnnotationWithArrayParsing() throws Exception {
-        List<Tag> tags = getScenarioModelBuilder().toTags( AnnotationWithArrayValueTestClass.class.getAnnotations()[0] );
-        assertThat( tags ).hasSize( 2 );
-        assertThat( tags.get( 0 ).getName() ).isEqualTo( "AnnotationWithArray" );
-        assertThat( tags.get( 0 ).getValues() ).containsExactly( "foo" );
-        assertThat( tags.get( 1 ).getName() ).isEqualTo( "AnnotationWithArray" );
-        assertThat( tags.get( 1 ).getValues() ).containsExactly( "bar" );
-    }
-
-    @IsTag( explodeArray = false )
-    @Retention( RetentionPolicy.RUNTIME )
-    @interface AnnotationWithoutExplodedArray {
-        String[] value();
-    }
-
-    @AnnotationWithoutExplodedArray( { "foo", "bar" } )
-    static class AnnotationWithoutExplodedArrayValueTestClass {}
-
-    @Test
-    public void testAnnotationWithoutExplodedArrayParsing() throws Exception {
-        List<Tag> tags = getScenarioModelBuilder().toTags( AnnotationWithoutExplodedArrayValueTestClass.class.getAnnotations()[0] );
-        assertThat( tags ).hasSize( 1 );
-        assertThat( tags.get( 0 ).getName() ).isEqualTo( "AnnotationWithoutExplodedArray" );
-        assertThat( tags.get( 0 ).getValues() ).containsExactly( "foo", "bar" );
-    }
-
-    @IsTag( description = "Some Description" )
-    @Retention( RetentionPolicy.RUNTIME )
-    @interface TagWithDescription {}
-
-    @TagWithDescription
-    static class AnnotationWithDescription {}
-
-    @Test
-    public void testAnnotationWithDescription() throws Exception {
-        List<Tag> tags = getScenarioModelBuilder().toTags( AnnotationWithDescription.class.getAnnotations()[0] );
-        assertThat( tags ).hasSize( 1 );
-        assertThat( tags.get( 0 ).getDescription() ).isEqualTo( "Some Description" );
-    }
-
-    @IsTag( description = "Some Description", ignoreValue = true )
-    @Retention( RetentionPolicy.RUNTIME )
-    @TagWithDescription
-    @interface TagWithDescriptionAndIgnoreValue {
-        String value();
-    }
-
-    @TagWithDescriptionAndIgnoreValue( value = "some value" )
-    static class AnnotationWithDescriptionAndIgnoreValue {}
-
-    @Test
-    public void testAnnotationWithDescriptionAndIgnoreValue() throws Exception {
-        List<Tag> tags = getScenarioModelBuilder().toTags( AnnotationWithDescriptionAndIgnoreValue.class.getAnnotations()[0] );
-        assertThat( tags ).hasSize( 1 );
-        assertThat( tags.get( 0 ).getValues() ).isEmpty();
-        assertThat( tags.get( 0 ).getDescription() ).isEqualTo( "Some Description" );
-        assertThat( tags.get( 0 ).getTags() ).hasSize( 1 );
-    }
-
-    @IsTag
-    @Retention( RetentionPolicy.RUNTIME )
-    @interface ParentTag {}
-
-    @IsTag
-    @Retention( RetentionPolicy.RUNTIME )
-    @interface ParentTagWithValue {
-        String value();
-    }
-
-    @ParentTagWithValue( "SomeValue" )
-    @ParentTag
-    @IsTag
-    @Retention( RetentionPolicy.RUNTIME )
-    @interface TagWithParentTags {}
-
-    @TagWithParentTags
-    static class AnnotationWithParentTag {}
-
-    @Test
-    public void testAnnotationWithParentTag() throws Exception {
-        List<Tag> tags = getScenarioModelBuilder().toTags( AnnotationWithParentTag.class.getAnnotations()[0] );
-        assertThat( tags ).hasSize( 1 );
-        assertThat( tags.get( 0 ).getTags() ).containsAll( Arrays.asList(
-            this.getClass().getName() + "$ParentTag", this.getClass().getName() + "$ParentTagWithValue-SomeValue" ) );
-    }
-
-    @IsTag( value = "default" )
-    @Retention( RetentionPolicy.RUNTIME )
-    @interface DynamicTag {}
-
-    @Test
-    public void testAddTagDynamically() throws Exception {
+    public void testAddTagDynamically() {
         ReportModel reportModel = new ReportModel();
         ScenarioModelBuilder scenarioModelBuilder = getScenarioModelBuilder();
-        scenarioModelBuilder.setReportModel( reportModel );
-        scenarioModelBuilder.scenarioStarted( "Test" );
+        scenarioModelBuilder.setReportModel(reportModel);
+        scenarioModelBuilder.scenarioStarted("Test");
 
-        scenarioModelBuilder.tagAdded( DynamicTag.class, "A", "B" );
-        scenarioModelBuilder.tagAdded( DynamicTag.class );
-        assertThat( reportModel.getTagMap() ).hasSize( 3 );
+        scenarioModelBuilder.tagAdded(DynamicTag.class, "A", "B");
+        scenarioModelBuilder.tagAdded(DynamicTag.class);
+        assertThat(reportModel.getTagMap()).hasSize(3);
 
         Iterator<Tag> iterator = reportModel.getTagMap().values().iterator();
-        assertThat( iterator.next().getValues() ).containsExactly( "A" );
-        assertThat( iterator.next().getValues() ).containsExactly( "B" );
-        assertThat( iterator.next().getValues() ).containsExactly( "default" );
+        assertThat(iterator.next().getValues()).containsExactly("A");
+        assertThat(iterator.next().getValues()).containsExactly("B");
+        assertThat(iterator.next().getValues()).containsExactly("default");
     }
 
     @DataProvider
     public static Object[][] testData() {
         return new Object[][] {
-            { 5, 6, 30 },
-            { 2, 2, 4 },
-            { -5, 1, -5 },
+            {5, 6, 30},
+            {2, 2, 4},
+            {-5, 1, -5},
         };
     }
 
     @Test
-    @UseDataProvider( "testData" )
-    public void test( int a, int b, int expectedResult ) throws Throwable {
+    @UseDataProvider("testData")
+    public void test(int a, int b, int expectedResult) throws Throwable {
         String description = "values can be multiplied";
-        startScenario( description );
+        startScenario(description);
 
-        given().$d_and_$d( a, b );
+        given().$d_and_$d(a, b);
         when().both_values_are_multiplied_with_each_other();
-        then().the_result_is( expectedResult );
+        then().the_result_is(expectedResult);
 
         getScenario().finished();
         ScenarioModel model = getScenario().getScenarioModel();
 
-        assertThat( model.getDescription() ).isEqualTo( description );
+        assertThat(model.getDescription()).isEqualTo(description);
 
-        ScenarioCaseModel case0 = model.getCase( 0 );
-        assertThat( case0.getExecutionStatus() ).isEqualTo( ExecutionStatus.SUCCESS );
-        assertThat( case0.getCaseNr() ).isEqualTo( 1 );
-        assertThat( case0.getExplicitArguments() ).isEmpty();
-        assertThat( case0.getSteps() ).hasSize( 3 );
-        assertThat( case0.getSteps() ).extracting( "failed" ).isEqualTo( asList( false, false, false ) );
-        assertThat( case0.getSteps() ).extracting( "pending" ).isEqualTo( asList( false, false, false ) );
-        assertThat( case0.getSteps() ).extracting( "skipped" ).isEqualTo( asList( false, false, false ) );
+        ScenarioCaseModel case0 = model.getCase(0);
+        assertThat(case0.getExecutionStatus()).isEqualTo(ExecutionStatus.SUCCESS);
+        assertThat(case0.getCaseNr()).isEqualTo(1);
+        assertThat(case0.getExplicitArguments()).isEmpty();
+        assertThat(case0.getSteps()).hasSize(3);
+        assertThat(case0.getSteps()).extracting("failed").isEqualTo(asList(false, false, false));
+        assertThat(case0.getSteps()).extracting("pending").isEqualTo(asList(false, false, false));
+        assertThat(case0.getSteps()).extracting("skipped").isEqualTo(asList(false, false, false));
 
-        StepModel step0 = case0.getSteps().get( 0 );
-        assertThat( step0.getWords() ).hasSize( 4 );
-        assertThat( step0.getCompleteSentence() ).isEqualTo( "Given " + a + " and " + b );
-        assertThat( extractIsArg( step0.getWords() ) ).isEqualTo( Arrays.asList( false, true, false, true ) );
+        StepModel step0 = case0.getSteps().get(0);
+        assertThat(step0.getWords()).hasSize(4);
+        assertThat(step0.getCompleteSentence()).isEqualTo("Given " + a + " and " + b);
+        assertThat(extractIsArg(step0.getWords())).isEqualTo(Arrays.asList(false, true, false, true));
 
-        StepModel step2 = case0.getSteps().get( 2 );
-        assertThat( step2.getWords() ).hasSize( 3 );
-        assertThat( extractIsArg( step2.getWords() ) ).isEqualTo( Arrays.asList( false, false, true ) );
+        StepModel step2 = case0.getSteps().get(2);
+        assertThat(step2.getWords()).hasSize(3);
+        assertThat(extractIsArg(step2.getWords())).isEqualTo(Arrays.asList(false, false, true));
     }
 
-    public static List<Boolean> extractIsArg( List<Word> words ) {
+    public static List<Boolean> extractIsArg(List<Word> words) {
         ArrayList<Boolean> result = Lists.newArrayList();
-        for( Word word : words ) {
-            result.add( word.isArg() );
+        for (Word word : words) {
+            result.add(word.isArg());
         }
         return result;
     }
@@ -279,251 +116,270 @@ public class ScenarioModelBuilderTest extends ScenarioTestBaseForTesting<GivenTe
     @DataProvider
     public static Object[][] argumentTestData() {
         return new Object[][] {
-            { null, "null" },
-            { "Foo", "Foo" },
-            { 123, "123" },
-            { true, "true" },
-            { new String[] { "a" }, "a" },
-            { new String[] {}, "" },
-            { new String[][] { { "a", "b" }, { "c" } }, "a, b, c" },
+            {null, "null"},
+            {"Foo", "Foo"},
+            {123, "123"},
+            {true, "true"},
+            {new String[] {"a"}, "a"},
+            {new String[] {}, ""},
+            {new String[][] {{"a", "b"}, {"c"}}, "a, b, c"},
         };
     }
 
     @Test
-    @UseDataProvider( "argumentTestData" )
-    public void testArrayArguments( Object argument, String expected ) throws Throwable {
-        startScenario( "test" );
+    @UseDataProvider("argumentTestData")
+    public void testArrayArguments(Object argument, String expected) throws Throwable {
+        startScenario("test");
 
-        given().an_array( argument );
+        given().an_array(argument);
 
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getWords().get( 2 ).getValue() ).isEqualTo( expected );
+        assertThat(step.getWords().get(2).getValue()).isEqualTo(expected);
     }
 
     @Test
     public void characters_are_not_dropped_when_using_the_As_annotation() throws Throwable {
-        startScenario( "Scenario with a @As tag" );
-        given().a_step_with_a_bracket_after_a_dollar( 42 );
+        startScenario("Scenario with a @As tag");
+        given().a_step_with_a_bracket_after_a_dollar(42);
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getCompleteSentence() ).isEqualTo( "Given a step with a bracket after a dollar 42 ]" );
+        assertThat(step.getCompleteSentence()).isEqualTo("Given a step with a bracket after a dollar 42 ]");
     }
 
     @Test
     public void As_on_overridden_methods_is_correctly_evaluated() throws Throwable {
-        ExtendedGivenTestStep stage = getScenario().addStage( ExtendedGivenTestStep.class );
-        startScenario( "Scenario with a @As tag" );
+        ExtendedGivenTestStep stage = getScenario().addStage(ExtendedGivenTestStep.class);
+        startScenario("Scenario with a @As tag");
         stage.abstract_step();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getCompleteSentence() ).isEqualTo( "an overridden description" );
+        assertThat(step.getCompleteSentence()).isEqualTo("an overridden description");
     }
 
     @Test
     public void setName_is_working_correctly_on_CurrentStep() throws Throwable {
-        GivenTestStep stage = getScenario().addStage( GivenTestStep.class );
-        startScenario( "Test Scenario" );
+        GivenTestStep stage = getScenario().addStage(GivenTestStep.class);
+        startScenario("Test Scenario");
         stage.given().a_step_that_sets_the_name();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getName() ).isEqualTo( "another name" );
-        assertThat( step.getCompleteSentence() ).isEqualTo( "given another name" );
+        assertThat(step.getName()).isEqualTo("another name");
+        assertThat(step.getCompleteSentence()).isEqualTo("given another name");
     }
 
     @Test
     public void setName_is_working_correctly_on_CurrentStep_with_steps_with_arguments() throws Throwable {
-        GivenTestStep stage = getScenario().addStage( GivenTestStep.class );
-        startScenario( "Test Scenario" );
-        stage.given().a_step_that_sets_the_name_with_an_argument( "argument" );
+        GivenTestStep stage = getScenario().addStage(GivenTestStep.class);
+        startScenario("Test Scenario");
+        stage.given().a_step_that_sets_the_name_with_an_argument("argument");
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getName() ).isEqualTo( "another name argument" );
-        assertThat( step.getCompleteSentence() ).isEqualTo( "given another name argument" );
+        assertThat(step.getName()).isEqualTo("another name argument");
+        assertThat(step.getCompleteSentence()).isEqualTo("given another name argument");
     }
 
     @Test
     public void setComment_is_working_correctly_on_CurrentStep() throws Throwable {
-        GivenTestStep stage = getScenario().addStage( GivenTestStep.class );
-        startScenario( "Test Scenario" );
+        GivenTestStep stage = getScenario().addStage(GivenTestStep.class);
+        startScenario("Test Scenario");
         stage.given().a_step_that_sets_a_comment();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getComment() ).isEqualTo( "a comment" );
+        assertThat(step.getComment()).isEqualTo("a comment");
     }
 
     @Test
     public void a_custom_AsProvider_can_be_used() throws Throwable {
-        startScenario( "Scenario with a @As tag" );
+        startScenario("Scenario with a @As tag");
         given().a_step_with_an_As_annotation_and_a_custom_provider();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getCompleteSentence() )
-            .isEqualTo( "Given Custom AsProvider output: a_step_with_an_As_annotation_and_a_custom_provider" );
+        assertThat(step.getCompleteSentence())
+            .isEqualTo("Given Custom AsProvider output: a_step_with_an_As_annotation_and_a_custom_provider");
+    }
+
+    @Test
+    public void timings_are_evaluated_with_filler_words() throws Throwable {
+        startScenario("nasiges");
+        given().something().and().something_else();
+        getScenario().finished();
+        ScenarioModel scenarioModel = getScenario().getScenarioModel();
+
     }
 
     @Test
     public void camel_case_is_supported_in_steps() throws Throwable {
-        startScenario( "Scenario camel case steps" );
+        startScenario("Scenario camel case steps");
         given().aStepInCamelCase();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getCompleteSentence() ).isEqualTo( "Given a step in camel case" );
+        assertThat(step.getCompleteSentence()).isEqualTo("Given a step in camel case");
     }
 
     @Test
     public void camel_case_is_supported_in_steps_with_parameters() throws Throwable {
-        startScenario( "Scenario camel case steps with parameter" );
-        given().aStepInCamelCaseWithA$Parameter( "dollar" );
+        startScenario("Scenario camel case steps with parameter");
+        given().aStepInCamelCaseWithA$Parameter("dollar");
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getCompleteSentence() ).isEqualTo( "Given a step in camel case with a dollar parameter" );
+        assertThat(step.getCompleteSentence()).isEqualTo("Given a step in camel case with a dollar parameter");
     }
 
     @Test
     public void all_uppercase_steps_are_formatted_correctly() throws Throwable {
-        startScenario( "Scenario with all uppercase step" );
+        startScenario("Scenario with all uppercase step");
         given().ALLUPPERCASE();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getCompleteSentence() ).isEqualTo( "Given ALLUPPERCASE" );
+        assertThat(step.getCompleteSentence()).isEqualTo("Given ALLUPPERCASE");
     }
 
     @Test
     public void the_Description_annotation_on_intro_words_is_evaluated() throws Throwable {
-        startScenario( "Scenario with an @As annotation" );
+        startScenario("Scenario with an @As annotation");
         given().an_intro_word_with_an_as_annotation().something();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getWords().get( 0 ).getValue() ).isEqualTo( "another description" );
+        assertThat(step.getWords().get(0).getValue()).isEqualTo("another description");
     }
 
     @Test
     public void filler_words_are_prepended_to_stage_methods() throws Throwable {
-        startScenario( "Scenario with filler words" );
+        startScenario("Scenario with filler words");
         given().there().is().something();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getCompleteSentence() ).isEqualTo( "Given there is something" );
+        assertThat(step.getCompleteSentence()).isEqualTo("Given there is something");
     }
 
     @Test
     public void the_Description_annotation_on_filler_words_is_evaluated() throws Throwable {
-        startScenario( "Scenario with @As annotation on filler words" );
+        startScenario("Scenario with @As annotation on filler words");
         given().a().filler_word_with_an_as_annotation().and_with().something_else();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getCompleteSentence() ).isEqualTo( "Given a Filler Word and with something else" );
+        assertThat(step.getCompleteSentence()).isEqualTo("Given a Filler Word and with something else");
     }
 
     @Test
     public void filler_words_can_be_joined_to_previous_words() throws Throwable {
-        startScenario( "Scenario with filler word joined to a previous word" );
+        startScenario("Scenario with filler word joined to a previous word");
         given().there().is().something_filled().comma().another().something_filled().and_with().something_else();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getCompleteSentence() )
-            .isEqualTo( "Given there is something filled, another something filled and with something else" );
+        assertThat(step.getCompleteSentence())
+            .isEqualTo("Given there is something filled, another something filled and with something else");
     }
 
     @Test
     public void filler_words_can_surround_words() throws Throwable {
-        startScenario( "Scenario with filler words surrounding a word" );
+        startScenario("Scenario with filler words surrounding a word");
         given().there().is().open_bracket().something().close_bracket();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getCompleteSentence() )
-            .isEqualTo( "Given there is (something)" );
+        assertThat(step.getCompleteSentence())
+            .isEqualTo("Given there is (something)");
     }
 
     @Test
     public void filler_words_can_be_used_at_the_end_of_a_sentence() throws Throwable {
-        startScenario( "Scenario with filler words at the end of sentences" );
+        startScenario("Scenario with filler words at the end of sentences");
         given().something().colon().and().something_else().full_stop();
         getScenario().finished();
-        StepModel firstStep  = getScenario().getScenarioCaseModel().getFirstStep();
-        StepModel secondStep = getScenario().getScenarioCaseModel().getStep( 1 );
-        assertThat( firstStep.getCompleteSentence() ).isEqualTo( "Given something:" );
-        assertThat( secondStep.getCompleteSentence() ).isEqualTo( "and something else." );
+        StepModel firstStep = getScenario().getScenarioCaseModel().getFirstStep();
+        StepModel secondStep = getScenario().getScenarioCaseModel().getStep(1);
+        assertThat(firstStep.getCompleteSentence()).isEqualTo("Given something:");
+        assertThat(secondStep.getCompleteSentence()).isEqualTo("and something else.");
     }
 
     @Test
     public void printf_annotation_uses_the_PrintfFormatter() throws Throwable {
-        startScenario( "printf_annotation_uses_the_PrintfFormatter" );
-        given().a_step_with_a_printf_annotation_$( 5.2 );
+        startScenario("printf_annotation_uses_the_PrintfFormatter");
+        given().a_step_with_a_printf_annotation_$(5.2);
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getWords().get( 2 ).getFormattedValue() ).isEqualTo( String.format( "%.2f", 5.2 ) );
+        assertThat(step.getWords().get(2).getFormattedValue()).isEqualTo(String.format("%.2f", 5.2));
     }
 
     @Test
     public void testTagEquals() {
-        assertThat( new Tag( "test", "1" ) ).isEqualTo( new Tag( "test", "1" ) );
+        assertThat(new Tag("test", "1")).isEqualTo(new Tag("test", "1"));
     }
 
-    static abstract class AbstractStage {
+    abstract static class AbstractStage {
         public abstract void abstract_step();
     }
 
     static class ConcreteStage extends AbstractStage {
         @Override
-        public void abstract_step() {}
+        public void abstract_step() {
+        }
     }
 
     @Test
     public void abstract_steps_should_appear_in_the_report_model() throws Throwable {
-        ConcreteStage stage = addStage( ConcreteStage.class );
-        startScenario( "Test" );
+        ConcreteStage stage = addStage(ConcreteStage.class);
+        startScenario("Test");
         stage.abstract_step();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getWords().get( 0 ).getFormattedValue() ).isEqualTo( "abstract step" );
+        assertThat(step.getWords().get(0).getFormattedValue()).isEqualTo("abstract step");
     }
 
     @Test
-    public void DoNotIntercept_method_are_not_appearing_in_the_report() throws Throwable {
-        DoNotInterceptClass stage = addStage( DoNotInterceptClass.class );
-        startScenario( "Test" );
+    public void DoNotIntercept_methods_are_not_appearing_in_the_report() throws Throwable {
+        DoNotInterceptClass stage = addStage(DoNotInterceptClass.class);
+        startScenario("Test");
         stage.do_not_intercept();
         stage.normal_step();
         getScenario().finished();
         StepModel step = getScenario().getScenarioCaseModel().getFirstStep();
-        assertThat( step.getWords().get( 0 ).getFormattedValue() ).isEqualTo( "normal step" );
+        assertThat(step.getWords().get(0).getFormattedValue()).isEqualTo("normal step");
     }
 
     static class DoNotInterceptClass {
         @DoNotIntercept
-        public void do_not_intercept() {}
+        public void do_not_intercept() {
+        }
 
-        public void normal_step() {}
+        public void normal_step() {
+        }
     }
 
     @Test
     public void error_message_is_correctly_stored() throws Throwable {
-        FailingTestStage stage = addStage( FailingTestStage.class );
-        startScenario( "Test" );
+        FailingTestStage stage = addStage(FailingTestStage.class);
+        startScenario("Test");
         stage.a_failing_test();
         try {
             getScenario().finished();
-        } catch( Exception ignore ) {
-
+        } catch (Exception ignore) {
+            // exception is ignored on purpose
         }
         ScenarioCaseModel scenarioCaseModel = getScenario().getScenarioCaseModel();
-        assertThat( scenarioCaseModel.getErrorMessage() ).isEqualTo( "java.lang.IllegalArgumentException: test error" );
-        assertThat( scenarioCaseModel.getStackTrace().get( 0 ) ).matches(
-            "com.tngtech.jgiven.impl.ScenarioModelBuilderTest\\$FailingTestStage.a_failing_test\\(ScenarioModelBuilderTest.java:\\d+\\)" );
+        assertThat(scenarioCaseModel.getErrorMessage()).isEqualTo("java.lang.IllegalArgumentException: test error");
+        assertThat(scenarioCaseModel.getStackTrace().get(0)).matches(
+            "com.tngtech.jgiven.impl.ScenarioModelBuilderTest\\$FailingTestStage.a_failing_test\\(ScenarioModelBuilderTest.java:\\d+\\)");
     }
 
     static class FailingTestStage {
-        public FailingTestStage a_failing_test() { throw new IllegalArgumentException( "test error" ); }
+        FailingTestStage a_failing_test() {
+            throw new IllegalArgumentException("test error");
+        }
     }
 
     static class ExtendedGivenTestStep extends AbstractStage {
 
         @Override
-        @As( "an overridden description" )
+        @As("an overridden description")
         public void abstract_step() {
 
         }
+    }
+
+    @IsTag(value = "default")
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface DynamicTag {
     }
 }

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TagClassCollection.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TagClassCollection.java
@@ -1,0 +1,130 @@
+package com.tngtech.jgiven.impl.tag;
+
+import com.tngtech.jgiven.annotation.IsTag;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@SuppressWarnings({"checkstyle:OneTopLevelClass", "checkstyle:OuterTypeFilename"})
+@IsTag
+@Retention(RetentionPolicy.RUNTIME)
+@interface AnnotationWithoutValue {
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@AnnotationWithoutValue
+class AnnotationTestClass {
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@IsTag
+@Retention(RetentionPolicy.RUNTIME)
+@interface AnnotationWithSingleValue {
+    String value();
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@AnnotationWithSingleValue("testvalue")
+class AnnotationWithSingleValueTestClass {
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@IsTag(name = "AnotherName")
+@Retention(RetentionPolicy.RUNTIME)
+@interface AnnotationWithName {
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@AnnotationWithName()
+class AnnotationWithNameTestClass {
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@IsTag(ignoreValue = true)
+@Retention(RetentionPolicy.RUNTIME)
+@interface AnnotationWithIgnoredValue {
+    String value();
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@AnnotationWithIgnoredValue("testvalue")
+class AnnotationWithIgnoredValueTestClass {
+}
+
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@IsTag
+@Retention(RetentionPolicy.RUNTIME)
+@interface AnnotationWithArray {
+    String[] value();
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@AnnotationWithArray({"foo", "bar"})
+class AnnotationWithArrayValueTestClass {
+}
+
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@IsTag(explodeArray = false)
+@Retention(RetentionPolicy.RUNTIME)
+@interface AnnotationWithoutExplodedArray {
+    String[] value();
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@AnnotationWithoutExplodedArray({"foo", "bar"})
+class AnnotationWithoutExplodedArrayValueTestClass {
+}
+
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@IsTag(description = "Some Description")
+@Retention(RetentionPolicy.RUNTIME)
+@interface TagWithDescription {
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@TagWithDescription
+class AnnotationWithDescription {
+}
+
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@IsTag(description = "Some Description", ignoreValue = true)
+@Retention(RetentionPolicy.RUNTIME)
+@TagWithDescription
+@interface TagWithDescriptionAndIgnoreValue {
+    String value();
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@TagWithDescriptionAndIgnoreValue(value = "some value")
+class AnnotationWithDescriptionAndIgnoreValue {
+}
+
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@IsTag
+@Retention(RetentionPolicy.RUNTIME)
+@interface ParentTag {
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@IsTag
+@Retention(RetentionPolicy.RUNTIME)
+@interface ParentTagWithValue {
+    String value();
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@ParentTagWithValue("SomeValue")
+@ParentTag
+@IsTag
+@Retention(RetentionPolicy.RUNTIME)
+@interface TagWithParentTags {
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@TagWithParentTags
+class AnnotationWithParentTag {
+}

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TagCreatorTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TagCreatorTest.java
@@ -1,0 +1,92 @@
+package com.tngtech.jgiven.impl.tag;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.jgiven.config.DefaultConfiguration;
+import com.tngtech.jgiven.report.model.Tag;
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class TagCreatorTest {
+
+    private final TagCreator underTest = new TagCreator(new DefaultConfiguration());
+
+    @Test
+    public void testAnnotationParsing() {
+        Tag tag = getOnlyTagFor(AnnotationTestClass.class.getAnnotations()[0]);
+        assertThat(tag.getName()).isEqualTo("AnnotationWithoutValue");
+        assertThat(tag.getValues()).isEmpty();
+    }
+
+    @Test
+    public void testAnnotationWithValueParsing() {
+        Tag tag = getOnlyTagFor(AnnotationWithSingleValueTestClass.class.getAnnotations()[0]);
+        assertThat(tag.getName()).isEqualTo("AnnotationWithSingleValue");
+        assertThat(tag.getValues()).containsExactly("testvalue");
+    }
+
+    @Test
+    public void testAnnotationWithName() {
+        Tag tag = getOnlyTagFor(AnnotationWithNameTestClass.class.getAnnotations()[0]);
+        assertThat(tag.getName()).isEqualTo("AnotherName");
+        assertThat(tag.getValues()).isEmpty();
+        assertThat(tag.toIdString()).isEqualTo(AnnotationWithName.class.getName());
+    }
+
+    @Test
+    public void testAnnotationWithIgnoredValueParsing() {
+        Tag tag = getOnlyTagFor(AnnotationWithIgnoredValueTestClass.class.getAnnotations()[0]);
+        assertThat(tag.getName()).isEqualTo("AnnotationWithIgnoredValue");
+        assertThat(tag.getValues()).isEmpty();
+        assertThat(tag.toIdString()).isEqualTo(AnnotationWithIgnoredValue.class.getName());
+    }
+
+    @Test
+    public void testAnnotationWithoutExplodedArrayParsing() {
+        Tag tag = getOnlyTagFor(AnnotationWithoutExplodedArrayValueTestClass.class.getAnnotations()[0]);
+        assertThat(tag.getName()).isEqualTo("AnnotationWithoutExplodedArray");
+        assertThat(tag.getValues()).containsExactly("foo", "bar");
+    }
+
+    @Test
+    public void testAnnotationWithDescription() {
+        Tag tag = getOnlyTagFor(AnnotationWithDescription.class.getAnnotations()[0]);
+        assertThat(tag.getDescription()).isEqualTo("Some Description");
+    }
+
+    @Test
+    public void testAnnotationWithDescriptionAndIgnoreValue() {
+        Tag tag = getOnlyTagFor(AnnotationWithDescriptionAndIgnoreValue.class.getAnnotations()[0]);
+        assertThat(tag.getValues()).isEmpty();
+        assertThat(tag.getDescription()).isEqualTo("Some Description");
+        assertThat(tag.getTags()).hasSize(1);
+    }
+
+    @Test
+    public void testAnnotationWithParentTag() {
+        Tag tag = getOnlyTagFor(AnnotationWithParentTag.class.getAnnotations()[0]);
+        assertThat(tag.getTags()).containsAll(Arrays.asList(
+            ParentTag.class.getName(),
+            ParentTagWithValue.class.getPackage().getName() + ".ParentTagWithValue-SomeValue")
+        );
+    }
+
+    @Test
+    public void testAnnotationWithArrayParsing() {
+        List<Tag> tags = underTest.toTags(AnnotationWithArrayValueTestClass.class.getAnnotations()[0]);
+        assertThat(tags).hasSize(2);
+        assertThat(tags.get(0).getName()).isEqualTo("AnnotationWithArray");
+        assertThat(tags.get(0).getValues()).containsExactly("foo");
+        assertThat(tags.get(1).getName()).isEqualTo("AnnotationWithArray");
+        assertThat(tags.get(1).getValues()).containsExactly("bar");
+    }
+
+    private Tag getOnlyTagFor(Annotation annotation) {
+        List<Tag> tags = underTest.toTags(annotation);
+        assertThat(tags).hasSize(1);
+        return tags.get(0);
+    }
+}


### PR DESCRIPTION
The tag creation methods are strongly dependent on each other but apart from putting the end result into the models have nothing to do with model building.

They therefore should end up in their own class that is independent of the models.

Signed-off-by: l-1sqared <30831153+l-1squared@users.noreply.github.com>