### PR TITLE
Increase growth cutoff for ProxyClassPerformanceTest

### DIFF
--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ProxyClassPerformanceTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ProxyClassPerformanceTest.java
@@ -14,6 +14,8 @@ public class ProxyClassPerformanceTest {
 
     private static final int NUMBER_OF_RUNS = 10000;
     private static final int PROBE_INTERVAL = 100;
+    private static final double GROWTH_EXPECTED_IF_LAST_REPORTED_GROWTH_IS_POSITIVE = 0.11;
+
 
     @Test
     public void test_creation_of_proxy_classes() {
@@ -34,7 +36,7 @@ public class ProxyClassPerformanceTest {
         assertThat(averageConsumptionChange)
             .as("There is no net increase of memory consumption "
             + "for the continued creation and discarding of proxy classes.")
-            .isLessThanOrEqualTo(0);
+            .isLessThanOrEqualTo(GROWTH_EXPECTED_IF_LAST_REPORTED_GROWTH_IS_POSITIVE);
     }
 
     private List<Long> calculateChangeInMemoryConsumption(List<Long> record) {

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ProxyClassPerformanceTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ProxyClassPerformanceTest.java
@@ -14,7 +14,7 @@ public class ProxyClassPerformanceTest {
 
     private static final int NUMBER_OF_RUNS = 10000;
     private static final int PROBE_INTERVAL = 100;
-    private static final double GROWTH_EXPECTED_IF_LAST_REPORTED_GROWTH_IS_POSITIVE = 0.11;
+    private static final double GROWTH_EXPECTED_IF_LAST_REPORTED_GROWTH_IS_POSITIVE = 0.011;
 
 
     @Test


### PR DESCRIPTION
Previously the test failed for a scenario where the reported memory usage would be constant but increased for the last recorded item. In such a case the reported growth would not be 0, but looking at the record would reveal no continuous growth.

Therefore we now allow the last item in the record to be an increment by 1.

Signed-off-by: l-1sqared <30831153+l-1squared@users.noreply.github.com>