### PR TITLE
fixes #806: add a default definition for JUnit 5 @Tag annotations onl…

### DIFF
--- a/jgiven-junit5/src/main/java/com/tngtech/jgiven/junit5/JGivenExtension.java
+++ b/jgiven-junit5/src/main/java/com/tngtech/jgiven/junit5/JGivenExtension.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.*;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 
 import com.tngtech.jgiven.base.ScenarioTestBase;
+import com.tngtech.jgiven.config.AbstractJGivenConfiguration;
 import com.tngtech.jgiven.config.ConfigurationUtil;
 import com.tngtech.jgiven.impl.ScenarioBase;
 import com.tngtech.jgiven.impl.ScenarioHolder;
@@ -53,10 +54,12 @@ public class JGivenExtension implements
         }
         context.getStore( NAMESPACE ).put( REPORT_MODEL, reportModel );
 
-        ConfigurationUtil.getConfiguration( context.getTestClass().get() )
-            .configureTag( Tag.class )
-            .description( "JUnit 5 Tag" )
-            .color( "orange" );
+        AbstractJGivenConfiguration configuration = ConfigurationUtil.getConfiguration( context.getTestClass().get() );
+        if( configuration.getTagConfiguration( Tag.class ) == null ) {
+            configuration.configureTag( Tag.class )
+                .description( "JUnit 5 Tag" )
+                .color( "orange" );
+        }
     }
 
     @Override

--- a/jgiven-junit5/src/test/java/com/tngtech/jgiven/junit5/test/CustomJUnit5TagConfiguration.java
+++ b/jgiven-junit5/src/test/java/com/tngtech/jgiven/junit5/test/CustomJUnit5TagConfiguration.java
@@ -1,0 +1,15 @@
+package com.tngtech.jgiven.junit5.test;
+
+import com.tngtech.jgiven.config.AbstractJGivenConfiguration;
+import org.junit.jupiter.api.Tag;
+
+public class CustomJUnit5TagConfiguration extends AbstractJGivenConfiguration {
+
+    @Override
+    public void configure() {
+        configureTag( Tag.class )
+                .name( "custom name" )
+                .color( "blue" )
+                .description( "custom description" );
+    }
+}

--- a/jgiven-junit5/src/test/java/com/tngtech/jgiven/junit5/test/JUnit5ExtensionTest.java
+++ b/jgiven-junit5/src/test/java/com/tngtech/jgiven/junit5/test/JUnit5ExtensionTest.java
@@ -1,11 +1,13 @@
 package com.tngtech.jgiven.junit5.test;
 
 import com.tngtech.jgiven.annotation.Pending;
+import com.tngtech.jgiven.config.ConfigurationUtil;
+import com.tngtech.jgiven.config.TagConfiguration;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.tngtech.jgiven.Stage;
 import com.tngtech.jgiven.annotation.ScenarioStage;
 import com.tngtech.jgiven.junit5.JGivenExtension;
 
@@ -34,4 +36,14 @@ public class JUnit5ExtensionTest {
         whenStage.some_failing_step();
     }
 
+    @Test
+    @Tag( "test-tag" )
+    public void JUnit5_tags_are_converted_to_JGiven_tags_using_default_configuration() {
+        TagConfiguration configuration = ConfigurationUtil.getConfiguration( JUnit5ExtensionTest.class )
+                .getTagConfiguration( Tag.class );
+
+        Assertions.assertNotNull( configuration );
+        Assertions.assertEquals( "JUnit 5 Tag", configuration.getDescription() );
+        Assertions.assertEquals( "orange", configuration.getColor() );
+    }
 }

--- a/jgiven-junit5/src/test/java/com/tngtech/jgiven/junit5/test/JUnit5ExtensionWithJGivenConfigurationTest.java
+++ b/jgiven-junit5/src/test/java/com/tngtech/jgiven/junit5/test/JUnit5ExtensionWithJGivenConfigurationTest.java
@@ -1,0 +1,27 @@
+package com.tngtech.jgiven.junit5.test;
+
+import com.tngtech.jgiven.annotation.JGivenConfiguration;
+import com.tngtech.jgiven.config.ConfigurationUtil;
+import com.tngtech.jgiven.config.TagConfiguration;
+import com.tngtech.jgiven.junit5.JGivenExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith( JGivenExtension.class )
+@JGivenConfiguration( CustomJUnit5TagConfiguration.class )
+public class JUnit5ExtensionWithJGivenConfigurationTest {
+
+    @Test
+    @Tag( "test-tag" )
+    public void JUnit5_tags_are_converted_to_JGiven_tags_using_custom_configuration() {
+        TagConfiguration configuration = ConfigurationUtil.getConfiguration( JUnit5ExtensionWithJGivenConfigurationTest.class )
+                .getTagConfiguration( Tag.class );
+
+        Assertions.assertNotNull( configuration );
+        Assertions.assertEquals( "custom name", configuration.getName() );
+        Assertions.assertEquals( "custom description", configuration.getDescription() );
+        Assertions.assertEquals( "blue", configuration.getColor() );
+    }
+}


### PR DESCRIPTION
…y if a custom definition has not been provided by a custom configuration implementation