### PR TITLE
Annotate maven plugins mojo with threadSafe true

### DIFF
--- a/jgiven-maven-plugin/src/main/java/com/tngtech/jgiven/maven/JGivenReportMojo.java
+++ b/jgiven-maven-plugin/src/main/java/com/tngtech/jgiven/maven/JGivenReportMojo.java
@@ -18,7 +18,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-@Mojo( name = "report", defaultPhase = LifecyclePhase.VERIFY )
+@Mojo( name = "report", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class JGivenReportMojo extends AbstractMojo {
 
     /**


### PR DESCRIPTION
for running maven builds in parallel.  Regarding to https://github.com/TNG/JGiven/issues/823

Solution gained from:  
https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3  
and   
https://stackoverflow.com/questions/24448623/how-to-mark-maven-plugin-threadsafe  