### PR TITLE
Issue-829: Write Parallel JUnit 4 tests

### DIFF
--- a/jgiven-junit/build.gradle
+++ b/jgiven-junit/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "pl.pragmatists:JUnitParams:$junitParamsVersion"
+    testImplementation "com.googlecode.junit-toolbox:junit-toolbox:2.4"
     testImplementation "org.mockito:mockito-core:4.4.0"
 }
 

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/concurrency/JUnit4InheritedParallelizationTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/concurrency/JUnit4InheritedParallelizationTest.java
@@ -1,0 +1,36 @@
+package com.tngtech.jgiven.junit.concurrency;
+
+import com.googlecode.junittoolbox.ParallelParameterized;
+import com.tngtech.jgiven.junit.ScenarioTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@RunWith(ParallelParameterized.class)
+public class JUnit4InheritedParallelizationTest
+    extends ScenarioTest<Stages.ParallelGivenStage, Stages.ParallelWhenStage, Stages.ParallelThenStage> {
+
+    int i;
+
+    @Parameters
+    public static Iterable<Object[]>iterationProvider() {
+        return IntStream.range(0, 100)
+                .mapToObj(value -> new Object[]{value})
+                .collect(Collectors.toList());
+    }
+
+    public JUnit4InheritedParallelizationTest(int i){
+        this.i = i;
+    }
+
+
+    @Test
+    public void testParallelExecution() {
+        given().a_thread_local_scenario_state();
+        when().the_state_on_this_thread_is_set_to("I am the greatest " + i);
+        then().the_value_on_this_thread_is("I am the greatest " + i);
+    }
+}

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/concurrency/JUnit4InjectedParallelizationTest.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/concurrency/JUnit4InjectedParallelizationTest.java
@@ -1,0 +1,50 @@
+package com.tngtech.jgiven.junit.concurrency;
+
+import com.googlecode.junittoolbox.ParallelParameterized;
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ScenarioStage;
+import com.tngtech.jgiven.junit.SimpleScenarioTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@RunWith(ParallelParameterized.class)
+public class JUnit4InjectedParallelizationTest extends SimpleScenarioTest<JUnit4InjectedParallelizationTest.VoidStage> {
+
+    int i;
+
+    @Parameters
+    public static Iterable<Object[]>iterationProvider() {
+        return IntStream.range(0, 100)
+                .mapToObj(value -> new Object[]{value})
+                .collect(Collectors.toList());
+    }
+
+    public JUnit4InjectedParallelizationTest(int i){
+        this.i = i;
+    }
+
+    @ScenarioStage
+    private Stages.ParallelGivenStage parallelGivenStage;
+
+    @ScenarioStage
+    private Stages.ParallelWhenStage parallelWhenStage;
+
+    @ScenarioStage
+    private Stages.ParallelThenStage parallelThenStage;
+
+
+
+    @Test
+    public void testParallelExecution() {
+        parallelGivenStage.given().a_thread_local_scenario_state();
+        parallelWhenStage.when().the_state_on_this_thread_is_set_to("I am the best " + i);
+        parallelThenStage.then().the_value_on_this_thread_is("I am the best " + i);
+    }
+
+    static class VoidStage extends Stage<VoidStage>{}
+}
+

--- a/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/concurrency/Stages.java
+++ b/jgiven-junit/src/test/java/com/tngtech/jgiven/junit/concurrency/Stages.java
@@ -1,0 +1,55 @@
+package com.tngtech.jgiven.junit.concurrency;
+
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.ExpectedScenarioState;
+import com.tngtech.jgiven.annotation.ProvidedScenarioState;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("UnusedReturnValue")
+final class Stages {
+    private Stages() {
+    }
+
+
+    static class ParallelGivenStage extends Stage<ParallelGivenStage> {
+
+        @ProvidedScenarioState
+        private final ThreadLocal<String> scenarioState = new ThreadLocal<>();
+
+        ParallelGivenStage a_thread_local_scenario_state() {
+            logState(this, scenarioState);
+            return this;
+        }
+    }
+
+    static class ParallelWhenStage extends Stage<ParallelWhenStage> {
+
+        @ExpectedScenarioState
+        private ThreadLocal<String> scenarioState;
+
+        ParallelWhenStage the_state_on_this_thread_is_set_to(String value) {
+            logState(this, scenarioState);
+            scenarioState.set(value);
+            return this;
+        }
+    }
+
+    static class ParallelThenStage extends Stage<ParallelThenStage> {
+        @ExpectedScenarioState
+        private ThreadLocal<String> scenarioState;
+
+        ParallelThenStage the_value_on_this_thread_is(String expectation) {
+            logState(this, scenarioState);
+            assertThat(scenarioState.get()).isEqualTo(expectation);
+            return this;
+        }
+    }
+
+    private static void logState(Stage<?> stage, ThreadLocal<?> stageState) {
+        LoggerFactory.getLogger(stage.getClass()).info("Object {} on thread {} with state {} and thread local value {}",
+            stage, Thread.currentThread().getId(), stageState, stageState.get());
+    }
+
+}


### PR DESCRIPTION
The package with the dodgy name is actually a recommendation from the JUnit 4 site itself, therefore
I opted to use it here.

Contrary to JUnit5 I opted against having a second method in the classes, because paralellization works on class level only anyway which means that the method just lost what little use they had.

Signed-off-by: l-1squared <30831153+l-1squared@users.noreply.github.com>