### PR TITLE
Issue-868: make sure that the parents of a tag are known to the repor…

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
@@ -22,6 +22,7 @@ import com.tngtech.jgiven.format.ObjectFormatter;
 import com.tngtech.jgiven.impl.format.ParameterFormattingUtil;
 import com.tngtech.jgiven.impl.intercept.ScenarioListener;
 import com.tngtech.jgiven.impl.params.DefaultAsProvider;
+import com.tngtech.jgiven.impl.tag.ResolvedTags;
 import com.tngtech.jgiven.impl.tag.TagCreator;
 import com.tngtech.jgiven.impl.util.AnnotationUtil;
 import com.tngtech.jgiven.impl.util.AssertionUtil;
@@ -36,7 +37,6 @@ import com.tngtech.jgiven.report.model.ScenarioModel;
 import com.tngtech.jgiven.report.model.StepFormatter;
 import com.tngtech.jgiven.report.model.StepModel;
 import com.tngtech.jgiven.report.model.StepStatus;
-import com.tngtech.jgiven.report.model.Tag;
 import com.tngtech.jgiven.report.model.Word;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -496,17 +496,19 @@ public class ScenarioModelBuilder implements ScenarioListener {
         }
     }
 
-    private void addTags(List<Tag> tags) {
+    private void addTags(ResolvedTags tags) {
         if (tags.isEmpty()) {
             return;
         }
 
         if (reportModel != null) {
-            this.reportModel.addTags(tags);
+            this.reportModel.addTags(tags.getDeclaredTags());
+            //The report model needs to declare the parent tags in a tag map, or the tags cannot be displayed.
+            this.reportModel.addTags(tags.getParents());
         }
 
         if (scenarioModel != null) {
-            this.scenarioModel.addTags(tags);
+            this.scenarioModel.addTags(tags.getDeclaredTags());
         }
     }
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/tag/ResolvedTags.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/tag/ResolvedTags.java
@@ -1,0 +1,45 @@
+package com.tngtech.jgiven.impl.tag;
+
+import com.tngtech.jgiven.report.model.Tag;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Container for styled tags declared on a scenario, including the necessary parents to display them.
+ */
+public class ResolvedTags {
+    List<ResolvedTag> resolvedTags = new ArrayList<>();
+
+    public List<Tag> getDeclaredTags() {
+        return resolvedTags.stream().map(resolvedTag -> resolvedTag.tag).collect(Collectors.toList());
+    }
+
+    public List<Tag> getParents() {
+        return resolvedTags.stream().flatMap(resolvedTag -> resolvedTag.parents.stream()).collect(Collectors.toList());
+    }
+
+    public boolean isEmpty() {
+        return resolvedTags.isEmpty();
+    }
+
+    /**
+     * A single tag declared for a scenario and the parents necessary to display it.
+     */
+    public static class ResolvedTag {
+        public final Tag tag;
+        public final List<Tag> parents;
+
+        ResolvedTag(Tag tag, List<Tag> parents) {
+
+            this.tag = tag;
+            this.parents = parents;
+        }
+    }
+
+    static ResolvedTags from(ResolvedTag resolvedTag) {
+        ResolvedTags wrapper = new ResolvedTags();
+        wrapper.resolvedTags.add(resolvedTag);
+        return wrapper;
+    }
+}

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/tag/TagCollector.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/tag/TagCollector.java
@@ -1,0 +1,41 @@
+package com.tngtech.jgiven.impl.tag;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+class TagCollector implements Collector<ResolvedTags.ResolvedTag, ResolvedTags, ResolvedTags> {
+    @Override
+    public Supplier<ResolvedTags> supplier() {
+        return ResolvedTags::new;
+    }
+
+    @Override
+    public BiConsumer<ResolvedTags, ResolvedTags.ResolvedTag> accumulator() {
+        return (container, element) -> container.resolvedTags.add(element);
+    }
+
+    @Override
+    public BinaryOperator<ResolvedTags> combiner() {
+        return (one, other) -> {
+            one.resolvedTags.addAll(other.resolvedTags);
+            return one;
+        };
+    }
+
+    @Override
+    public Function<ResolvedTags, ResolvedTags> finisher() {
+        return Function.identity();
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+        Set<Characteristics> characteristics = new HashSet<>();
+        characteristics.add(Characteristics.IDENTITY_FINISH);
+        return characteristics;
+    }
+}

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/ResolvedTagsTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/ResolvedTagsTest.java
@@ -1,0 +1,24 @@
+package com.tngtech.jgiven.impl.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.jgiven.report.model.Tag;
+import org.junit.Test;
+
+public class ResolvedTagsTest {
+
+
+    @Test
+    public void testResolvedTagsFiltersForDirectTags() {
+        ResolvedTags underTest = TestTagGenerator.getEnumeratedResolvedTags(5);
+        assertThat(underTest.getDeclaredTags()).extracting(Tag::getFullType)
+            .containsExactly("tag1", "tag2", "tag3", "tag4", "tag5");
+    }
+
+    @Test
+    public void testResolvedTagsFiltersForParents() {
+        ResolvedTags underTest = TestTagGenerator.getEnumeratedResolvedTags(5);
+        assertThat(underTest.getParents()).extracting(Tag::getFullType)
+            .containsExactly("parent1", "parent2", "parent3", "parent4", "parent5");
+    }
+}

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TagClassCollection.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TagClassCollection.java
@@ -126,5 +126,12 @@ class AnnotationWithDescriptionAndIgnoreValue {
 
 @SuppressWarnings("checkstyle:OneTopLevelClass")
 @TagWithParentTags
+@IsTag
+@Retention(RetentionPolicy.RUNTIME)
+@interface TagWithGrandparentTags {
+}
+
+@SuppressWarnings("checkstyle:OneTopLevelClass")
+@TagWithParentTags
 class AnnotationWithParentTag {
 }

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TagCollectorTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TagCollectorTest.java
@@ -1,0 +1,34 @@
+package com.tngtech.jgiven.impl.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.jgiven.impl.tag.ResolvedTags.ResolvedTag;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.junit.Test;
+
+public class TagCollectorTest {
+
+    private final TagCollector underTest = new TagCollector();
+    private final TestTagGenerator tagGenerator = new TestTagGenerator();
+
+    @Test
+    public void testCollectorCollectsTags() {
+        ResolvedTag tag1 = tagGenerator.next();
+        ResolvedTag tag2 = tagGenerator.next();
+
+        ResolvedTags result = Stream.of(tag1, tag2).collect(underTest);
+
+        assertThat(result.resolvedTags).contains(tag1, tag2);
+    }
+
+    @Test
+    public void testCollectorCanMergeParallelResults() {
+        ResolvedTags resolvedTags = StreamSupport.stream(
+            ((Iterable<ResolvedTag>) () -> tagGenerator).spliterator(), true)
+            .limit(50)
+            .collect(underTest);
+        assertThat(resolvedTags.resolvedTags).hasSize(50);
+    }
+
+}

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TagCreatorTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TagCreatorTest.java
@@ -91,7 +91,8 @@ public class TagCreatorTest {
 
     @Test
     public void testAnnotationWithArrayParsing() {
-        List<Tag> tags = underTest.toTags(AnnotationWithArrayValueTestClass.class.getAnnotations()[0]);
+        List<Tag> tags =
+            underTest.toTags(AnnotationWithArrayValueTestClass.class.getAnnotations()[0]).getDeclaredTags();
         assertThat(tags).hasSize(2);
         assertThat(tags.get(0).getName()).isEqualTo("AnnotationWithArray");
         assertThat(tags.get(0).getValues()).containsExactly("foo");
@@ -99,8 +100,19 @@ public class TagCreatorTest {
         assertThat(tags.get(1).getValues()).containsExactly("bar");
     }
 
+    @Test
+    public void testAllParentsOfTagAreResolved() {
+        ResolvedTags resolvedTags = underTest.toTags(TagWithGrandparentTags.class);
+        assertThat(resolvedTags.getDeclaredTags())
+            .extracting(Tag::getName)
+            .containsExactly("TagWithGrandparentTags");
+        assertThat(resolvedTags.getParents())
+            .extracting(Tag::getName)
+            .containsExactlyInAnyOrder("TagWithParentTags", "ParentTag", "ParentTagWithValue");
+    }
+
     private Tag getOnlyTagFor(Annotation annotation) {
-        List<Tag> tags = underTest.toTags(annotation);
+        List<Tag> tags = underTest.toTags(annotation).getDeclaredTags();
         assertThat(tags).hasSize(1);
         return tags.get(0);
     }

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TestTagGenerator.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/tag/TestTagGenerator.java
@@ -1,0 +1,34 @@
+package com.tngtech.jgiven.impl.tag;
+
+import com.tngtech.jgiven.impl.tag.ResolvedTags.ResolvedTag;
+import com.tngtech.jgiven.report.model.Tag;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.stream.StreamSupport;
+
+class TestTagGenerator implements Iterator<ResolvedTag> {
+
+    int count = 0;
+
+    @Override
+    public boolean hasNext() {
+        return count < Integer.MAX_VALUE;
+    }
+
+    @Override
+    public ResolvedTag next() {
+        count++;
+        System.out.println("Generating Tag No. " + count);
+        return new ResolvedTag(
+            new Tag("tag" + count),
+            Collections.singletonList(new Tag("parent" + count))
+        );
+    }
+
+    static ResolvedTags getEnumeratedResolvedTags(int number) {
+        return StreamSupport.stream(
+                ((Iterable<ResolvedTag>) TestTagGenerator::new).spliterator(), false)
+            .limit(number)
+            .collect(new TagCollector());
+    }
+}

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/report/model/ReportModelIntegrationTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/report/model/ReportModelIntegrationTest.java
@@ -1,0 +1,50 @@
+package com.tngtech.jgiven.report.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.jgiven.ScenarioTestBaseForTesting;
+import com.tngtech.jgiven.Stage;
+import com.tngtech.jgiven.annotation.IsTag;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Collections;
+import org.junit.Test;
+
+public class ReportModelIntegrationTest extends ScenarioTestBaseForTesting<
+    ReportModelIntegrationTest.TestStage, ReportModelIntegrationTest.TestStage, ReportModelIntegrationTest.TestStage> {
+
+
+    @Test
+    @ChildTag
+    public void parent_tags_are_present_in_the_report_model() throws Throwable {
+        ReportModel model = new ReportModel();
+        getScenario().setModel(model);
+        getScenario().startScenario(getClass(),
+            getClass().getMethod("parent_tags_are_present_in_the_report_model"),
+            Collections.emptyList());
+        given();
+        when();
+        then();
+        getScenario().finished();
+        assertThat(model.getTagMap()).containsKeys(
+            "com.tngtech.jgiven.report.model.ReportModelIntegrationTest$ParentTag",
+            "com.tngtech.jgiven.report.model.ReportModelIntegrationTest$ChildTag"
+        );
+    }
+
+    static class TestStage extends Stage<TestStage> {
+    }
+
+    @IsTag
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ParentTag {
+    }
+
+    @IsTag
+    @ParentTag
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ChildTag {
+    }
+
+
+}


### PR DESCRIPTION
…t model

Commit fd978254a2494e8dde4bc194ea42251647c8fef2 in this repo removed a side effect during tag creation that ensured that parent tags of a declared tag were declared in the tag map of the report model. This is a prerequisite for the html app to work. Unfortuneately there was no test that ensured that the report model got the info.

Here, we changed the model such that the Tag creator actually publishes the parents that a tag has, such that the report model may consume them.

Signed-off-by: l-1sqared <30831153+l-1squared@users.noreply.github.com>