### PR TITLE
Checkout actions fetches whole repository

### DIFF
--- a/.github/workflows/jgiven_align_gh_pages.yml
+++ b/.github/workflows/jgiven_align_gh_pages.yml
@@ -10,11 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: get all git data
-        run: git fetch
-      - name: Checkout gh-pages
-        run:  git checkout -f gh-pages
+        with:
+          fetch-depth: '0' #fetch all history
+          ref: 'gh-pages'
+      - name: Configure git user
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
       - name: Rebase on master
         run:  git rebase origin/master
       - name: Replace version on origin
-        run:  git push --force-with-lease
+        run: git push --force-with-lease


### PR DESCRIPTION
Previously the repository did not checkout a single branch but actually a single commit, which it made into a unique ref for its own repo. Consequently, when attempting to rebase the entire history of gh-pages onto that commit the rebase would fail, because the base in the repo wasn't the actual master branch but only its latest commit which resulted in an unfitting history of that commit and a failing rebase.

Now that we check out everything from the start, this should work fine.

Signed-off-by: l-1sqared <30831153+l-1squared@users.noreply.github.com>