### PR TITLE
Fix Averaging in ProxyClassPerformanceTest

### DIFF
--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ProxyClassPerformanceTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/ProxyClassPerformanceTest.java
@@ -50,8 +50,8 @@ public class ProxyClassPerformanceTest {
     private double average(List<Long> data) {
         return data.stream()
             .mapToDouble(Double::valueOf)
-            .reduce((currentAverage, dataPoint) -> currentAverage + dataPoint / data.size())
-            .orElse(0.0);
+            .map(dataPoint -> dataPoint / data.size())
+            .sum();
     }
 
     private long calculateMemoryUsageRoundedDownToMebibytes() {


### PR DESCRIPTION
The reducer that we used here uses the first data point to determine the current average. Thus, when the there is an increment between the first and the second data point the increment will not get divided by the size of increments. This is incorrect and therefore we now divide all data points before summing up.

Signed-off-by: l-1sqared <30831153+l-1squared@users.noreply.github.com>