### PR TITLE
Issue-1013: only write a version when there is a version to write

### DIFF
--- a/.github/workflows/jgiven_examples_build.yml
+++ b/.github/workflows/jgiven_examples_build.yml
@@ -14,8 +14,6 @@ jobs:
           distribution: 'adopt'
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
-      - name: Grant execute permission for bash script
-        run: chmod +x scripts/local_release_with_version.sh
       - name: Produce a local release with version 1.1-t
         run: source scripts/local_release_with_version.sh
       - name: Test Kotlin Example Project
@@ -63,8 +61,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Grant execute permission for bash script
-        run: chmod +x scripts/local_release_with_version.sh
       - name: Load the bash script
         run: source scripts/local_release_with_version.sh
       - name: Test Java 11 Project

--- a/.github/workflows/jgiven_examples_build.yml
+++ b/.github/workflows/jgiven_examples_build.yml
@@ -1,9 +1,9 @@
-name: "Test example projects"
+name: "Test published JGiven"
 on: [push, pull_request]
 
 jobs:
   build_java8:
-    name: Build the examples on Java 8
+    name: Test the examples on Java 8
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -79,3 +79,13 @@ jobs:
           name: test-report-example-projects
           path: /home/runner/work/JGiven/JGiven/example-projects/*/build/reports/tests
           if-no-files-found: ignore
+  validate_publication_poms:
+    name: Validate the format of the published poms
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Load the bash script
+        run: scripts/local_release_with_version.sh
+      - name: Run validation
+        run: scripts/validate_poms.sh
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#v1.2.4
+##Fixed issues
+* Fixed incorrect POM that was published because our manual pom transcription writes a version tag even when none is required [#1013](https://github.com/TNG/JGiven/issues/1013) (thanks to jangalanski for reporting)
+
 # v1.2.3
 ## Fixed issues
 * Fixed build error when JGiven is used in conjuntion with openapi. [#947](https://github.com/TNG/JGiven/issues/947) (thanks to manoj-fd for reporting)

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,9 @@ subprojects {
                                     asNode().dependencies[0].appendNode('dependency').with {
                                         it.appendNode('groupId', dep.group)
                                         it.appendNode('artifactId', dep.name)
-                                        it.appendNode('version', dep.version)
+                                        if (dep.version != null && dep.version.trim() != "") {
+                                            it.appendNode('version', dep.version)
+                                        }
                                         it.appendNode('scope', 'provided')
                                     }
                                 }

--- a/scripts/validate_poms.sh
+++ b/scripts/validate_poms.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_LOCATION=$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")
+
+poms_in_publication_folder=$(find ${SCRIPT_LOCATION}/../ -name pom-default.xml | grep publications)
+failed_validations=""
+for pom in ${poms_in_publication_folder};do
+  if mvn validate -q -f "${pom}";then
+    continue
+  else
+    failed_validations="${failed_validations:-""} Validation failed for POM file '${pom}'\n"
+  fi
+done
+
+if [ -n "${failed_validations}" ];then
+  printf "${failed_validations}"
+  exit 1
+fi


### PR DESCRIPTION
The error happens here, because we write the "compileOnly" dependencies manually. In case of "compileOnly" dependencies gradle does not resolve any version. So for the JUnit5 dependencies gradle writes an empty version tag, producing an invalid pom.

However, gradle does correctly add the junit-bom to the pom as dependency management so that there should not be any version in that dependency in the first place.

Signed-off-by: l-1sqared <30831153+l-1squared@users.noreply.github.com>