### PR TITLE
fix: Kotlin name mangling

### DIFF
--- a/example-projects/kotlin/src/test/kotlin/com/tngtech/jgiven/example/projects/junit5/GivenStage.kt
+++ b/example-projects/kotlin/src/test/kotlin/com/tngtech/jgiven/example/projects/junit5/GivenStage.kt
@@ -17,4 +17,12 @@ open class GivenStage : Stage<GivenStage>() {
         this.message = message
         return self()
     }
+
+    @JvmInline
+    value class Username(val value: String)
+
+    open fun greeting(username: Username): GivenStage {
+        this.message = "Hello ${username.value}"
+        return self()
+    }
 }

--- a/example-projects/kotlin/src/test/kotlin/com/tngtech/jgiven/example/projects/junit5/JUnit5Test.kt
+++ b/example-projects/kotlin/src/test/kotlin/com/tngtech/jgiven/example/projects/junit5/JUnit5Test.kt
@@ -28,4 +28,11 @@ class JUnit5Test {
         whenStage.`when`().handle_message()
         thenStage.then().the_result_is("Hello JUnit 5!")
     }
+
+    @Test
+    fun `test with value class`() {
+        givenStage.given().greeting(GivenStage.Username("Foo"))
+        whenStage.`when`().handle_message()
+        thenStage.then().the_result_is("Hello Foo 5!")
+    }
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/params/DefaultAsProvider.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/params/DefaultAsProvider.java
@@ -29,6 +29,11 @@ public class DefaultAsProvider implements AsProvider {
     }
 
     String methodNameToReadableText( String methodName ) {
+        // Kotlin mangles the name of some functions; see https://kotlinlang.org/docs/inline-classes.html#mangling
+        if (methodName.contains("-")) {
+            methodName = methodName.substring(0, methodName.lastIndexOf('-'));
+        }
+
         if( methodName.contains( "_" ) ) {
             return WordUtil.fromSnakeCase( methodName );
         }

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/params/DefaultAsProviderTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/params/DefaultAsProviderTest.java
@@ -17,7 +17,8 @@ public class DefaultAsProviderTest {
             "FooBar, foo bar",
             "Foo_Bar, Foo Bar",
             "foo_bar_Baz, foo bar Baz",
-            "foo_bar, foo bar"
+            "foo_bar, foo bar",
+            "foo bar-lkjw24dsgf", "foo bar"
     } )
     @Test
     public void test_method_to_readable_text( String methodName, String expectedText ) {

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/params/DefaultAsProviderTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/params/DefaultAsProviderTest.java
@@ -18,7 +18,7 @@ public class DefaultAsProviderTest {
             "Foo_Bar, Foo Bar",
             "foo_bar_Baz, foo bar Baz",
             "foo_bar, foo bar",
-            "foo bar-lkjw24dsgf", "foo bar"
+            "foo bar-lkjw24dsgf, foo bar"
     } )
     @Test
     public void test_method_to_readable_text( String methodName, String expectedText ) {


### PR DESCRIPTION
## Problem
Kotlin mangles some names when value classes are used. See https://kotlinlang.org/docs/inline-classes.html#mangling
This mangled name is then used in the reports.

## Solution
This commit removes the dash and following chars from the default method name.
Thus leading to better readable reports.

This should not affect Java projects as far as I can tell since "-" is not valid in method names (see https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.8).

## Alternatives
- Instead of having this case covered by JGiven, we could also override the method name in all affected methods using `@As` (repeated test name), `@As` with a custom provider, or Kotlins `@JvmName` (repeated test name).

- Another alternative would be to allow setting the default `AsProvider` (same as with the formatter currently). I presume this would mean adding the config in all our test classes, but not on each method individually.

## Thanks for your time! 