### PR TITLE
Feature/more flexible as provider

### DIFF
--- a/docs/report_generation.adoc
+++ b/docs/report_generation.adoc
@@ -217,3 +217,6 @@ jgiven.report.text.color
 jgiven.report.filterStackTrace=true
 ----
 Configuration defined via Java system properties will take precedence over values in the configuration file.
+
+=== Configuration class
+Finally, JGiven allows to set a custom derivative of `AbstractJGivenConfiguration` on the class level via the `@JGivenConfiguration` annotation. Tag configuration, formatter configuration and a default `xref:_overriding_the_default_reporting[@As provider]` provider can be set there.

--- a/docs/stages.adoc
+++ b/docs/stages.adoc
@@ -36,9 +36,10 @@ I fill out the registration form
 ----
 The nested steps will appear as a collapsible group in the HTML report.
 
+[#_overriding_the_default_reporting]
 === Overriding the Default Reporting
 
-Sometimes it is necessary to override the default way of the step reporting. For example, if you want to use special characters that are not allowed in Java methods names, such as `(`, `+`, or `%`. You can then use the `@As` annotation to specify what JGiven should put into the report.
+Sometimes it is necessary to override the default way of the step reporting. For example, if you want to use special characters that are not allowed in Java methods names, such as `(`, `+`, or `%`, you can then use the `@As` annotation to specify what JGiven should put into the report.
 
 For example, if you define the following step method:
 
@@ -66,6 +67,7 @@ public MyStage some_step() {
     return self();
 }
 ----
+In addition, the `@As` annotation allows declaring an `AsProvider` that handles the step name generation. A default provider can be set via `@JGivenConfiguration` annotation in the class referenced there.
 
 === Completely Hide Steps
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/As.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/As.java
@@ -9,8 +9,8 @@ import java.lang.annotation.Target;
 import com.tngtech.jgiven.impl.params.DefaultAsProvider;
 
 /**
- * This annotation can be used to override the default
- * representation for a step method, test method or class name in the report.
+ * This annotation can be used to override the default representation for the items it was annotated with in the report.
+ * Works on step method, test method or class name.
  *
  * <p>
  * Note that the '$' character keeps its special meaning and will be

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/JGivenConfiguration.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/annotation/JGivenConfiguration.java
@@ -12,6 +12,7 @@ import com.tngtech.jgiven.config.AbstractJGivenConfiguration;
  * <ul>
  *     <li>Tags</li>
  *     <li>Global formatter</li>
+ *     <li>Default {@link As} provider</li>
  * </ul>
  */
 @Retention( RetentionPolicy.RUNTIME )

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/config/AbstractJGivenConfiguration.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/config/AbstractJGivenConfiguration.java
@@ -102,6 +102,11 @@ public abstract class AbstractJGivenConfiguration implements FormatterConfigurat
         return testClassSuffixRegEx;
     }
 
+    /**
+     * Set a default interpreter for method names for all items that are subject to this configuration.
+     * Can be overriden by {@link com.tngtech.jgiven.annotation.As} annotation.
+     * @see com.tngtech.jgiven.annotation.As
+     */
     public void setAsProvider(AsProvider asProvider) {
         if (asProvider == null) {
             throw new JGivenWrongUsageException("A custom AsProvider must not be set to null");

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/config/AbstractJGivenConfiguration.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/config/AbstractJGivenConfiguration.java
@@ -103,7 +103,7 @@ public abstract class AbstractJGivenConfiguration implements FormatterConfigurat
     }
 
     public void setAsProvider(AsProvider asProvider) {
-        if(asProvider == null) {
+        if (asProvider == null) {
             throw new JGivenWrongUsageException("A custom AsProvider must not be set to null");
         }
         this.asProvider = asProvider;

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/config/AbstractJGivenConfiguration.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/config/AbstractJGivenConfiguration.java
@@ -1,6 +1,7 @@
 package com.tngtech.jgiven.config;
 
 import com.tngtech.jgiven.annotation.AsProvider;
+import com.tngtech.jgiven.exception.JGivenWrongUsageException;
 import com.tngtech.jgiven.impl.params.DefaultAsProvider;
 import java.lang.annotation.Annotation;
 import java.util.Map;
@@ -102,6 +103,9 @@ public abstract class AbstractJGivenConfiguration implements FormatterConfigurat
     }
 
     public void setAsProvider(AsProvider asProvider) {
+        if(asProvider == null) {
+            throw new JGivenWrongUsageException("A custom AsProvider must not be set to null");
+        }
         this.asProvider = asProvider;
     }
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/config/AbstractJGivenConfiguration.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/config/AbstractJGivenConfiguration.java
@@ -1,5 +1,7 @@
 package com.tngtech.jgiven.config;
 
+import com.tngtech.jgiven.annotation.AsProvider;
+import com.tngtech.jgiven.impl.params.DefaultAsProvider;
 import java.lang.annotation.Annotation;
 import java.util.Map;
 
@@ -10,6 +12,8 @@ import com.tngtech.jgiven.impl.format.FormatterCache;
 public abstract class AbstractJGivenConfiguration implements FormatterConfiguration {
     private final Map<Class<? extends Annotation>, TagConfiguration> tagConfigurations = Maps.newHashMap();
     private final FormatterCache formatterCache = new FormatterCache();
+
+    private AsProvider asProvider = new DefaultAsProvider();
     private String testClassSuffixRegEx = "Tests?";
 
     /**
@@ -95,5 +99,13 @@ public abstract class AbstractJGivenConfiguration implements FormatterConfigurat
 
     public String getTestClassSuffixRegEx() {
         return testClassSuffixRegEx;
+    }
+
+    public void setAsProvider(AsProvider asProvider) {
+        this.asProvider = asProvider;
+    }
+
+    public AsProvider getAsProvider() {
+        return asProvider;
     }
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
@@ -47,7 +47,7 @@ import java.util.Stack;
 public class ScenarioModelBuilder implements ScenarioListener {
 
     private static final Set<String> STACK_TRACE_FILTER = ImmutableSet
-        .of("sun.reflect", "com.tngtech.jgiven.impl.intercept", "com.tngtech.jgiven.impl.intercept",
+        .of("sun.reflect", "com.tngtech.jgiven.impl.intercept",
             "$$EnhancerByCGLIB$$",
             "java.lang.reflect", "net.sf.cglib.proxy", "com.sun.proxy");
     private static final boolean FILTER_STACK_TRACE = Config.config().filterStackTrace();
@@ -70,7 +70,7 @@ public class ScenarioModelBuilder implements ScenarioListener {
         this.reportModel = reportModel;
     }
 
-    private Stack<Integer> discrepancyOnLayer = new Stack<>();
+    private final Stack<Integer> discrepancyOnLayer = new Stack<>();
 
     @Override
     public void scenarioStarted(String description) {
@@ -408,16 +408,7 @@ public class ScenarioModelBuilder implements ScenarioListener {
     }
 
     private void readAnnotations(Class<?> testClass, Method method) {
-        String scenarioDescription = method.getName();
-
-        if (method.isAnnotationPresent(Description.class)) {
-            scenarioDescription = method.getAnnotation(Description.class).value();
-        } else {
-            As as = method.getAnnotation(As.class);
-            AsProvider provider = getAsProvider(as);
-            scenarioDescription = provider.as(as, method);
-        }
-
+        String scenarioDescription = evaluateMethodForDescription(method);
         scenarioStarted(scenarioDescription);
 
         if (method.isAnnotationPresent(ExtendedDescription.class)) {
@@ -432,6 +423,14 @@ public class ScenarioModelBuilder implements ScenarioListener {
         if (scenarioCaseModel.getCaseNr() == 1) {
             addTags(testClass.getAnnotations());
             addTags(method.getAnnotations());
+        }
+    }
+    private String evaluateMethodForDescription(Method method) {
+        if (method.isAnnotationPresent(Description.class)) {
+            return method.getAnnotation(Description.class).value();
+        } else {
+            As as = method.getAnnotation(As.class);
+            return getAsProvider(as).as(as, method);
         }
     }
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
@@ -277,10 +277,7 @@ public class ScenarioModelBuilder implements ScenarioListener {
         }
 
         As as = paramMethod.getAnnotation(As.class);
-        AsProvider provider = as != null
-            ? ReflectionUtil.newInstance(as.provider())
-            : configuration.getAsProvider();
-        return provider.as(as, paramMethod);
+        return getAsProvider(as).as(as, paramMethod);
     }
 
     public void setStatus(ExecutionStatus status) {
@@ -417,10 +414,8 @@ public class ScenarioModelBuilder implements ScenarioListener {
             scenarioDescription = method.getAnnotation(Description.class).value();
         } else {
             As as = method.getAnnotation(As.class);
-            AsProvider provider = as != null
-                ? ReflectionUtil.newInstance(as.provider())
-                : configuration.getAsProvider();
-                scenarioDescription = provider.as(as, method);
+            AsProvider provider = getAsProvider(as);
+            scenarioDescription = provider.as(as, method);
         }
 
         scenarioStarted(scenarioDescription);
@@ -522,5 +517,11 @@ public class ScenarioModelBuilder implements ScenarioListener {
 
     public ScenarioCaseModel getScenarioCaseModel() {
         return scenarioCaseModel;
+    }
+
+    private AsProvider getAsProvider(As as) {
+        return as != null
+            ? ReflectionUtil.newInstance(as.provider())
+            : configuration.getAsProvider();
     }
 }

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
@@ -415,11 +415,12 @@ public class ScenarioModelBuilder implements ScenarioListener {
 
         if (method.isAnnotationPresent(Description.class)) {
             scenarioDescription = method.getAnnotation(Description.class).value();
-        } else if (method.isAnnotationPresent(As.class)) {
+        } else {
             As as = method.getAnnotation(As.class);
-
-            AsProvider provider = ReflectionUtil.newInstance(as.provider());
-            scenarioDescription = provider.as(as, method);
+            AsProvider provider = as != null
+                ? ReflectionUtil.newInstance(as.provider())
+                : configuration.getAsProvider();
+                scenarioDescription = provider.as(as, method);
         }
 
         scenarioStarted(scenarioDescription);

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/ScenarioModelBuilder.java
@@ -21,7 +21,6 @@ import com.tngtech.jgiven.exception.JGivenWrongUsageException;
 import com.tngtech.jgiven.format.ObjectFormatter;
 import com.tngtech.jgiven.impl.format.ParameterFormattingUtil;
 import com.tngtech.jgiven.impl.intercept.ScenarioListener;
-import com.tngtech.jgiven.impl.params.DefaultAsProvider;
 import com.tngtech.jgiven.impl.tag.ResolvedTags;
 import com.tngtech.jgiven.impl.tag.TagCreator;
 import com.tngtech.jgiven.impl.util.AnnotationUtil;
@@ -280,7 +279,7 @@ public class ScenarioModelBuilder implements ScenarioListener {
         As as = paramMethod.getAnnotation(As.class);
         AsProvider provider = as != null
             ? ReflectionUtil.newInstance(as.provider())
-            : new DefaultAsProvider();
+            : configuration.getAsProvider();
         return provider.as(as, paramMethod);
     }
 

--- a/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/ReportModel.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/report/model/ReportModel.java
@@ -7,7 +7,7 @@ import com.google.common.collect.Maps;
 import com.tngtech.jgiven.annotation.As;
 import com.tngtech.jgiven.annotation.AsProvider;
 import com.tngtech.jgiven.annotation.Description;
-import com.tngtech.jgiven.impl.params.DefaultAsProvider;
+import com.tngtech.jgiven.config.ConfigurationUtil;
 import com.tngtech.jgiven.impl.util.AssertionUtil;
 import com.tngtech.jgiven.impl.util.ReflectionUtil;
 import java.util.Comparator;
@@ -180,7 +180,7 @@ public class ReportModel {
         As as = testClass.getAnnotation(As.class);
         AsProvider provider = as != null
             ? ReflectionUtil.newInstance(as.provider())
-            : new DefaultAsProvider();
+            : ConfigurationUtil.getConfiguration(testClass).getAsProvider();
         name = provider.as(as, testClass);
     }
 

--- a/jgiven-junit/src/main/java/com/tngtech/jgiven/junit/ScenarioModelHolder.java
+++ b/jgiven-junit/src/main/java/com/tngtech/jgiven/junit/ScenarioModelHolder.java
@@ -26,7 +26,7 @@ public class ScenarioModelHolder {
      * @param testClass the test class to get the report model for
      * @return the report model for the given test class
      */
-    public ReportModel getReportModel( Class<? extends Object> testClass ) {
+    public ReportModel getReportModel( Class<?> testClass ) {
         synchronized( reportModels ) {
             ReportModel reportModel = reportModels.get( testClass.getCanonicalName() );
 

--- a/jgiven-junit5/src/main/java/com/tngtech/jgiven/junit5/JGivenExtension.java
+++ b/jgiven-junit5/src/main/java/com/tngtech/jgiven/junit5/JGivenExtension.java
@@ -111,11 +111,7 @@ public class JGivenExtension implements
         if (testInstance instanceof ScenarioTestBase) {
             scenario = ((ScenarioTestBase<?, ?, ?>) testInstance).getScenario();
         } else {
-            if (currentScenario == null) {
-                scenario = new ScenarioBase();
-            } else {
-                scenario = currentScenario;
-            }
+            scenario = currentScenario == null ? new ScenarioBase() : currentScenario;
         }
 
         if (scenario != currentScenario) {


### PR DESCRIPTION
Missing:
[x] documentation
[x] tests
[x] works for method names.
[x] check once for a real JGiven test
[x] double check using As provider for method descriptions -- getDescription uses it. If anything we're more correct now