### PR TITLE
fix(Issue-1801): JGiven now can handle null parameters from JUnit5

### DIFF
--- a/jgiven-junit5/src/main/java/com/tngtech/jgiven/junit5/ArgumentReflectionUtil.java
+++ b/jgiven-junit5/src/main/java/com/tngtech/jgiven/junit5/ArgumentReflectionUtil.java
@@ -42,7 +42,7 @@ class ArgumentReflectionUtil {
                                 && invocationContext.getClass().getCanonicalName().equals(PARAMETERIZED_TEST_INVOCATION_CONTEXT)) {
                             Object arguments = ReflectionUtil.getFieldValueOrNull("arguments", invocationContext, ERROR);
                             if (arguments instanceof Arguments) {
-                                List<Object> args = List.of(((Arguments) arguments).get());
+                                List<Object> args = Arrays.asList(((Arguments) arguments).get());
                                 namedArgs = ParameterNameUtil.mapArgumentsWithParameterNames(context.getTestMethod().get(), args);
                             } else {
                                 log.warn(ERROR + " The type of arguments in the invocation context has changed. Please write a bug report.");

--- a/jgiven-junit5/src/test/java/com/tngtech/jgiven/junit5/test/ParameterizedTestTest.java
+++ b/jgiven-junit5/src/test/java/com/tngtech/jgiven/junit5/test/ParameterizedTestTest.java
@@ -4,24 +4,65 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.*;
 
 import com.tngtech.jgiven.annotation.CaseAs;
 import com.tngtech.jgiven.junit5.JGivenExtension;
 import com.tngtech.jgiven.junit5.ScenarioTest;
 
-@ExtendWith( JGivenExtension.class )
+import java.util.stream.Stream;
+
+@ExtendWith(JGivenExtension.class)
 public class ParameterizedTestTest extends ScenarioTest<GivenStage, WhenStage, ThenStage> {
 
-    @ParameterizedTest( name = "{index} [{arguments}] param name" )
-    @ValueSource( strings = { "Hello", "World" } )
-    @CaseAs( "Case $1" )
-    public void parameterized_scenario( String param ) {
+    @ParameterizedTest(name = "{index} [{arguments}] param name")
+    @ValueSource(strings = {"Hello", "World"})
+    @NullSource
+    @CaseAs("Case $1")
+    public void parameterized_scenario(String param) {
         given().some_state();
-        when().some_action_with_a_parameter( param );
+        when().some_action_with_a_parameter(param);
         then().some_outcome();
 
-        assertThat( getScenario().getScenarioCaseModel().getDescription() ).isIn( "Case Hello", "Case World" );
+        assertThat(getScenario().getScenarioCaseModel().getDescription()).isIn("Case Hello", "Case World", "Case null");
     }
 
+    @ParameterizedTest
+    @MethodSource("parametersWithNullInSubsequentTestCases")
+    void parameterized_scenario_with_null_arguments_in_subsequent_test_cases(String param1, String param2) {
+        given().some_state();
+        when().some_action_with_a_parameter(param1);
+        when().some_action_with_a_parameter(param2);
+        then().some_outcome();
+
+        assertThat(getScenario().getScenarioCaseModel().getExplicitArguments()).containsExactly(String.valueOf(param1), String.valueOf(param2));
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("parametersWithNullInFirstTestCase")
+    void parameterized_scenario_with_null_arguments_in_first_iteration(String param1, String param2) {
+        given().some_state();
+        when().some_action_with_a_parameter(param1);
+        when().some_action_with_a_parameter(param2);
+        then().some_outcome();
+
+        assertThat(getScenario().getScenarioCaseModel().getExplicitArguments()).containsExactly(String.valueOf(param1), String.valueOf(param2));
+    }
+
+    static Stream<Arguments> parametersWithNullInSubsequentTestCases() {
+        return Stream.of(
+                Arguments.of("Hello", "World"),
+                Arguments.of(null, "World"),
+                Arguments.of("Hello", null),
+                Arguments.of(null, null)
+        );
+    }
+
+    static Stream<Arguments> parametersWithNullInFirstTestCase() {
+        return Stream.of(
+                Arguments.of(null, "World"),
+                Arguments.of("Hello", "World")//,
+        );
+    }
 }


### PR DESCRIPTION
According to the test description this only shows up when the null value is in the second argument. I didn't quite understand why this is the case. But since the distincition between the first and subsequent cases is important, I've added a respective case.