### PR TITLE
fix link of Big Techday talk & Java aktuell

### DIFF
--- a/_posts/2014-09-08-JavaAktuell.markdown
+++ b/_posts/2014-09-08-JavaAktuell.markdown
@@ -4,9 +4,9 @@ title:  "JGiven article published in Java aktuell"
 date:   2014-09-08 13:00:00
 categories: news
 ---
-The german magazine [Java aktuell](https://www.ijug.eu/java-aktuell.html) has accepted our article on JGiven! It will be published with the 04/2014 edition.
+The German magazine [Java aktuell](https://www.ijug.eu/de/java-aktuell/) has accepted our article on JGiven! It will be published with the 04/2014 edition.
 
-A special print with the JGiven article is available as [PDF]({{site.baseurl}}/articles/JavaAktuell_042014_JGiven.pdf) (in german).
+A special print with the JGiven article is available as [PDF]({{site.baseurl}}/articles/JavaAktuell_042014_JGiven.pdf) (in German).
 
 [jgiven-gh]: https://github.com/TNG/JGiven
 [jgiven]:    https://jgiven.org

--- a/_posts/2015-07-04-video-on-bigtechday8.markdown
+++ b/_posts/2015-07-04-video-on-bigtechday8.markdown
@@ -4,7 +4,7 @@ title:  "Video of the Talk on JGiven at Big Techday 8 available"
 date:   2015-07-03 13:00:00
 categories: news
 ---
-The [video](https://www.techcast.com/events/bigtechday8/maffei-1345/) of the talk 'Behavior-Driven Development in Plain Java' which Jan Schäfer gave at the TNG Big TechDay is now available.
+The [video](https://www.youtube.com/watch?v=gh_yjb3x8Yc) of the talk 'Behavior-Driven Development in Plain Java', which Jan Schäfer gave at the TNG Big Techday 8, is now available.
 
 [jgiven-gh]: https://github.com/TNG/JGiven
 [jgiven]:    https://jgiven.org

--- a/docs.md
+++ b/docs.md
@@ -16,7 +16,7 @@ permalink: /docs/
 
 ### Conference Talks
 
-* [Behavior-Driven Development in Plain Java](http://www.techcast.com/events/bigtechday8/maffei-1345/), by Jan Schäfer at TNG Big TechDay 8, June 2015
+* [Behavior-Driven Development in Plain Java](https://www.youtube.com/watch?v=gh_yjb3x8Yc), by Jan Schäfer at the TNG Big Techday 8, June 2015
 
 ### Articles
 

--- a/index.md
+++ b/index.md
@@ -82,9 +82,9 @@ Marie-Laure Thuret (<a href="https://twitter.com/mlthuret">@mlthuret</a>) and Cl
 
 <iframe class="shadow-frame" width="560" height="315" src="https://www.youtube.com/embed/4oFl4nxoshM" frameborder="0" allowfullscreen></iframe>
 
-### Talk on JGiven at BigTechday 8
+### Talk on JGiven at the TNG Big Techday 8
 
-Jan Schäfer gave a talk on JGiven at the BigTechday 8. It explains the rationale behind JGiven and gives an introduction into the main features of JGiven.
+Jan Schäfer gave a talk on JGiven at the TNG Big Techday 8. It explains the rationale behind JGiven and gives an introduction into the main features of JGiven.
 
 <iframe class="shadow-frame" width="560" height="315" src="https://www.youtube.com/embed/gh_yjb3x8Yc" frameborder="0" allowfullscreen></iframe>
 


### PR DESCRIPTION
This PR fixes some links on https://jgiven.org/ (i.e. branch `gh-pages`).

The [old link](https://media.techcast.cloud//bigtechday8/maffei-1345) to the video of the Big Techday talk is not available anymore.