### PR TITLE
 Replace usages of Executable with AccessibleObject to match method signature of Paranamer 2.8.3

### DIFF
--- a/jgiven-core/src/main/java/com/tngtech/jgiven/impl/util/ParameterNameUtil.java
+++ b/jgiven-core/src/main/java/com/tngtech/jgiven/impl/util/ParameterNameUtil.java
@@ -8,7 +8,7 @@ import com.tngtech.jgiven.report.model.NamedArgument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Executable;
+import java.lang.reflect.AccessibleObject;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -23,7 +23,7 @@ public class ParameterNameUtil {
     /**
      * @throws NullPointerException iif {@code constructorOrMethod} is {@code null}
      */
-    public static List<NamedArgument> mapArgumentsWithParameterNames(Executable constructorOrMethod, List<Object> arguments) {
+    public static List<NamedArgument> mapArgumentsWithParameterNames(AccessibleObject constructorOrMethod, List<Object> arguments) {
         Preconditions.checkNotNull( constructorOrMethod, "constructorOrMethod must not be null." );
         Preconditions.checkNotNull( arguments, "arguments must not be null" );
 
@@ -48,7 +48,7 @@ public class ParameterNameUtil {
         return result;
     }
 
-    private static List<String> getParameterNamesUsingParanamer(Executable constructorOrMethod) {
+    private static List<String> getParameterNamesUsingParanamer(AccessibleObject constructorOrMethod) {
         try {
             return Arrays.asList( PARANAMER.lookupParameterNames( constructorOrMethod ) );
 

--- a/jgiven-core/src/test/java/com/tngtech/jgiven/impl/util/ParameterNameUtilTest.java
+++ b/jgiven-core/src/test/java/com/tngtech/jgiven/impl/util/ParameterNameUtilTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Executable;
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
 import java.util.List;
 
@@ -33,10 +33,10 @@ public class ParameterNameUtilTest {
 
     @Test
     @UseDataProvider( "dataProviderMapArgumentsWithParameterNamesOf" )
-    public void testMapArgumentsWithParameterNamesOf(Executable contructorOrMethod, List<Object> arguments,
+    public void testMapArgumentsWithParameterNamesOf(AccessibleObject constructorOrMethod, List<Object> arguments,
                                                      List<NamedArgument> expected) {
         // When:
-        List<NamedArgument> result = ParameterNameUtil.mapArgumentsWithParameterNames( contructorOrMethod, arguments );
+        List<NamedArgument> result = ParameterNameUtil.mapArgumentsWithParameterNames( constructorOrMethod, arguments );
 
         // Then:
         assertThat( result ).containsExactly( expected.toArray( new NamedArgument[0] ) );

--- a/jgiven-junit/src/main/java/com/tngtech/jgiven/junit/JGivenMethodRule.java
+++ b/jgiven-junit/src/main/java/com/tngtech/jgiven/junit/JGivenMethodRule.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Executable;
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.util.*;
 
@@ -145,7 +145,7 @@ public class JGivenMethodRule implements MethodRule {
 
     @VisibleForTesting
     static List<NamedArgument> getNamedArguments(Statement base, FrameworkMethod method, Object target) {
-        Executable constructorOrMethod = method.getMethod();
+        AccessibleObject constructorOrMethod = method.getMethod();
 
         List<Object> arguments = Collections.emptyList();
 


### PR DESCRIPTION
The current master branch of JGiven uses Paranamer-2.8.3. However, based on the discussion of [Paranamer issue #47](https://github.com/paul-hammant/paranamer/issues/47) I think that the current master (= the pending JGiven release 2.0.3) is missing some changes to fix #1960.

[Paranamer issue #47](https://github.com/paul-hammant/paranamer/issues/47) states that the following method signature change happened with the update of Paranamer 2.8 to 2.8.1: 

```java
// Paranamer 2.8
java.lang.String[] com.thoughtworks.paranamer.Paranamer.lookupParameterNames(java.lang.reflect.AccessibleObject, boolean)
``` 

```java
// Paranamer 2.8.1
java.lang.String[] com.thoughtworks.paranamer.Paranamer.lookupParameterNames(java.lang.reflect.Executable, boolean)
```

The end result of [Paranamer issue #47](https://github.com/paul-hammant/paranamer/issues/47) is that this method signature change has been rolled back. 
Therefore, Paranamer 2.8.3 again uses the method signature of Paranamer 2.8, i.e.

```java
// Paranamer 2.8.3
java.lang.String[] com.thoughtworks.paranamer.Paranamer.lookupParameterNames(java.lang.reflect.AccessibleObject, boolean)
``` 

This change is has to be reflected in the current master of JGiven (= the pending JGiven release 2.0.3).